### PR TITLE
LFSP-131: Switch to laa-spring-boot-common gradle plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@
 
 version: 2
 
-# Uncomment 'registries' section to receive dependabot updates for 'laa-ccms-spring-boot-common'.
+# Uncomment 'registries' section to receive dependabot updates for 'laa-spring-boot-common'.
 # Ensure you have created a personal access token in GitHub and configured it with repo, write:packages and read:packages access.
 # The token must also be authorized with (MoJ) SSO. See link below for guidance:
 # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
 #registries:
 #  spring-boot-common-github-packages:
 #    type: maven-repository
-#    url: https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common
+#    url: https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common
 #    username: <your-username-here>
 #    password: ${{ secrets.REPO_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-The project uses the `laa-ccms-spring-boot-gradle-plugin` Gradle plugin which provides
+The project uses the `laa-spring-boot-gradle-plugin` Gradle plugin which provides
 sensible defaults for the following plugins:
 
 - [Checkstyle](https://docs.gradle.org/current/userguide/checkstyle_plugin.html)
@@ -15,7 +15,7 @@ sensible defaults for the following plugins:
 - [Test Logger](https://github.com/radarsh/gradle-test-logger-plugin)
 - [Versions](https://github.com/ben-manes/gradle-versions-plugin)
 
-The plugin is provided by -  [laa-ccms-spring-boot-common](https://github.com/ministryofjustice/laa-ccms-spring-boot-common), where you can find
+The plugin is provided by -  [laa-spring-boot-common](https://github.com/ministryofjustice/laa-spring-boot-common), where you can find
 more information regarding setup and usage.
 
 ### Project Structure

--- a/scheme-api/build.gradle
+++ b/scheme-api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.openapi.generator' version '7.14.0'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin'
+    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
 }
 
 repositories {

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.freefair.lombok' version '8.14.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin'
+    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
     id "io.sentry.jvm.gradle" version "5.9.0"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     repositories {
         maven {
             name = "gitHubPackages"
-            url = 'https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common'
+            url = 'https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common'
             credentials {
                 username = System.getenv("GITHUB_ACTOR")?.trim() ?: settings.ext.find('project.ext.gitPackageUser')
                 password = System.getenv("GITHUB_TOKEN")?.trim() ?: settings.ext.find('project.ext.gitPackageKey')
@@ -13,7 +13,7 @@ pluginManagement {
     }
 
     plugins {
-        id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.41'
+        id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '1.0.0'
     }
 }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-131)

Replace all references to laa-ccms-spring-boot-common to laa-spring-boot-common in the gradle build and settings files and README.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
