### PR TITLE
LFSP-163: Remove global exception hander for generic exceptions

### DIFF
--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package uk.gov.justice.laa.fee.scheme.exception;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import java.time.OffsetDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,7 +8,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import uk.gov.justice.laa.fee.scheme.model.ErrorResponse;
 
@@ -77,15 +74,6 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(PoliceStationFeeNotFoundException.class)
   public ResponseEntity<ErrorResponse> handlePoliceStationFeeNotfound(PoliceStationFeeNotFoundException ex) {
     return handleException(ex, HttpStatus.NOT_FOUND);
-  }
-
-  /**
-   * Global exception handler for all other exceptions.
-   */
-  @ExceptionHandler(Exception.class)
-  @ResponseStatus(INTERNAL_SERVER_ERROR)
-  public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
-    return handleException(ex, INTERNAL_SERVER_ERROR);
   }
 
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandlerTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandlerTest.java
@@ -152,15 +152,4 @@ class GlobalExceptionHandlerTest {
     assertThat(response.getBody().getMessage()).isEqualTo("Request method 'GET' is not supported");
   }
 
-  @Test
-  void handleGenericExceptionFound() {
-    RuntimeException exception = new RuntimeException("some error");
-
-    ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleGenericException(exception);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().getStatus()).isEqualTo(500);
-    assertThat(response.getBody().getMessage()).isEqualTo("some error");
-  }
 }


### PR DESCRIPTION
## What

Remove global exception hander for generic exceptions as it has uncovered an underlying issue where the /metrics endpoint
which does not exist in our app. Is continuously being called and the error keeps getting logged and triggers sentry.
This is a quick workaround until the underlying issue is fixed and then the exception handler can be re-introduced.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
