### PR TITLE
LFSP-193 Associated Civil escape logic

### DIFF
--- a/scheme-api/open-api-specification.yml
+++ b/scheme-api/open-api-specification.yml
@@ -249,7 +249,7 @@ components:
           type: number
           format: double
           description: "The net travel cost requested."
-        netWaitingCosts:
+        netWaitingCostsAmount:
           type: number
           format: double
           description: "The net waiting cost requested."

--- a/scheme-service/src/integrationtest/java/uk/gov/justice/laa/fee/scheme/controller/FeeCalculationControllerIntegrationTest.java
+++ b/scheme-service/src/integrationtest/java/uk/gov/justice/laa/fee/scheme/controller/FeeCalculationControllerIntegrationTest.java
@@ -97,6 +97,9 @@ public class FeeCalculationControllerIntegrationTest extends PostgresContainerTe
                   "feeCode": "ASMS",
                   "claimId": "claim_123",
                   "uniqueFileNumber": "020416/001",
+                  "netProfitCosts": 27.8,
+                  "netTravelCosts": 10.0,
+                  "netWaitingCosts": 11.5,
                   "netDisbursementAmount": 55.35,
                   "disbursementVatAmount": 11.07,
                   "vatIndicator": true
@@ -119,7 +122,10 @@ public class FeeCalculationControllerIntegrationTest extends PostgresContainerTe
                 "disbursementAmount": 55.35,
                 "requestedNetDisbursementAmount": 55.35,
                 "disbursementVatAmount": 11.07,
-                "fixedFeeAmount": 79.0
+                "fixedFeeAmount": 79.0,
+                "netProfitCostsAmount": 27.8,
+                "netTravelCostsAmount": 10.0,
+                "netWaitingCostsAmount": 11.5
                 }
               }
             """, STRICT));
@@ -665,7 +671,7 @@ public class FeeCalculationControllerIntegrationTest extends PostgresContainerTe
           "disbursementAmount": 123.38,
           "requestedNetDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "netWaitingCosts": %s,
+          "netWaitingCostsAmount": %s,
           "netTravelCostsAmount": %s,
           "fixedFeeAmount": %s
         }
@@ -723,7 +729,7 @@ public class FeeCalculationControllerIntegrationTest extends PostgresContainerTe
             "netProfitCostsAmount": %s,
             "requestedNetProfitCostsAmount": %s,
             "netTravelCostsAmount": 50,
-            "netWaitingCosts": 50
+            "netWaitingCostsAmount": 50
           }
         }
         """.formatted(feeCode, schemeId, expectedTotal, expectedVatAmount, expectedHourlyTotalAmount, netProfitCostsAmount, requestedNetProfitCostsAmount);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
@@ -1,0 +1,75 @@
+package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
+
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.VatUtil.getVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.VatUtil.getVatRateForDate;
+import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
+import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
+import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
+import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+
+/**
+ * Calculate the Associated Civil Work fee for a given fee entity and fee calculation request.
+ */
+@Slf4j
+@Component
+public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
+
+  @Override
+  public java.util.Set<CategoryType> getSupportedCategories() {
+    return java.util.Set.of(CategoryType.ASSOCIATED_CIVIL);
+  }
+
+  /**
+   * Calculated fee based on the provided fee entity and fee calculation request.
+   *
+   * @param feeCalculationRequest the request containing fee calculation data
+   * @return FeeCalculationResponse with calculated fee
+   */
+  @Override
+  public FeeCalculationResponse calculate(FeeCalculationRequest feeCalculationRequest, FeeEntity feeEntity) {
+
+    log.info("Get fields from fee calculation request");
+    Boolean vatApplicable = feeCalculationRequest.getVatIndicator();
+    LocalDate claimStartDate = FeeCalculationUtil.getFeeClaimStartDate(CategoryType.ASSOCIATED_CIVIL, feeCalculationRequest);
+    BigDecimal fixedFee = defaultToZeroIfNull(feeEntity.getFixedFee());
+
+    BigDecimal calculatedVatAmount = getVatAmount(fixedFee, claimStartDate, vatApplicable);
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    log.info("Calculate total fee amount with any disbursements and VAT where applicable");
+    BigDecimal finalTotal = fixedFee
+        .add(calculatedVatAmount)
+        .add(netDisbursementAmount)
+        .add(disbursementVatAmount);
+
+    log.info("Build fee calculation response");
+    return FeeCalculationResponse.builder()
+        .feeCode(feeCalculationRequest.getFeeCode())
+        .schemeId(feeEntity.getFeeScheme().getSchemeCode())
+        .claimId(feeCalculationRequest.getClaimId())
+        .escapeCaseFlag(false) // temp hard coded, till escape logic implemented
+        .feeCalculation(FeeCalculation.builder()
+            .totalAmount(toDouble(finalTotal))
+            .vatIndicator(vatApplicable)
+            .vatRateApplied(toDouble(getVatRateForDate(claimStartDate)))
+            .calculatedVatAmount(toDouble(calculatedVatAmount))
+            .disbursementAmount(toDouble(netDisbursementAmount))
+            .requestedNetDisbursementAmount(toDouble(netDisbursementAmount))
+            .disbursementVatAmount(toDouble(disbursementVatAmount))
+            .fixedFeeAmount(toDouble(fixedFee))
+            .build())
+        .build();
+  }
+}

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MagsYouthCourtFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MagsYouthCourtFixedFeeCalculator.java
@@ -105,7 +105,7 @@ public class MagsYouthCourtFixedFeeCalculator implements FeeCalculator {
         .requestedNetDisbursementAmount(toDouble(requestedNetDisbursementAmount))
         .disbursementVatAmount(toDouble(requestedDisbursementVatAmount))
         .fixedFeeAmount(toDouble(fixedFeeAmount))
-        .netWaitingCosts(toDouble(requestedWaitingCosts))
+        .netWaitingCostsAmount(toDouble(requestedWaitingCosts))
         .netTravelCostsAmount(toDouble(requestedTravelCosts))
         .build();
 

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculator.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 
-import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ASSOCIATED_CIVIL;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.CLAIMS_PUBLIC_AUTHORITIES;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.CLINICAL_NEGLIGENCE;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.COMMUNITY_CARE;
@@ -33,7 +32,7 @@ public class StandardFixedFeeCalculator implements FeeCalculator {
 
   @Override
   public Set<CategoryType> getSupportedCategories() {
-    return Set.of(ASSOCIATED_CIVIL, CLAIMS_PUBLIC_AUTHORITIES, CLINICAL_NEGLIGENCE, COMMUNITY_CARE, DEBT,
+    return Set.of(CLAIMS_PUBLIC_AUTHORITIES, CLINICAL_NEGLIGENCE, COMMUNITY_CARE, DEBT,
         EDUCATION, FAMILY, HOUSING, HOUSING_HLPAS, MENTAL_HEALTH, MISCELLANEOUS, PUBLIC_LAW, WELFARE_BENEFITS
     );
   }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
@@ -91,7 +91,7 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
             .hourlyTotalAmount(toDouble(profitAndAdditionalCosts))
             .netProfitCostsAmount(toDouble(requestedNetProfitCosts))
             .requestedNetProfitCostsAmount(toDouble(requestedNetProfitCosts))
-            .netWaitingCosts(toDouble(requestedWaitingCosts))
+            .netWaitingCostsAmount(toDouble(requestedWaitingCosts))
             .netTravelCostsAmount(toDouble(requestedTravelCosts))
             .build())
         .build();

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
@@ -54,18 +54,17 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal feeTotal = netProfitCosts.add(netCostOfCounsel);
 
-    boolean escaped = false;
     List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     BigDecimal escapeThresholdLimit = feeEntity.getEscapeThresholdLimit();
+    boolean isEscaped = feeTotal.compareTo(escapeThresholdLimit) > 0;
 
-    if (feeTotal.compareTo(escapeThresholdLimit) > 0) {
+    if (isEscaped) {
       log.warn("Fee total exceeds escape threshold limit");
       validationMessages.add(ValidationMessagesInner.builder()
           .message(WARNING_CODE_DESCRIPTION)
           .type(WARNING)
           .build());
       feeTotal = escapeThresholdLimit;
-      escaped = true;
     }
 
     // Apply VAT where applicable
@@ -85,7 +84,7 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
         .schemeId(feeEntity.getFeeScheme().getSchemeCode())
         .claimId(feeCalculationRequest.getClaimId())
         .validationMessages(validationMessages)
-        .escapeCaseFlag(escaped)
+        .escapeCaseFlag(isEscaped)
         .feeCalculation(FeeCalculation.builder()
             .totalAmount(toDouble(totalAmount))
             .vatIndicator(vatApplicable)

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
@@ -112,7 +112,7 @@ public final class FeeCalculationUtil {
   /**
    * Return appropriate date based on Category Type of the claim request.
    *
-   * @param categoryType CategoryType
+   * @param categoryType          CategoryType
    * @param feeCalculationRequest FeeCalculationRequest
    * @return LocalDate
    */
@@ -122,7 +122,7 @@ public final class FeeCalculationUtil {
           DateUtil.toLocalDate(Objects.requireNonNull(feeCalculationRequest.getUniqueFileNumber()));
       case MAGS_COURT_DESIGNATED, MAGS_COURT_UNDESIGNATED, YOUTH_COURT_DESIGNATED, YOUTH_COURT_UNDESIGNATED ->
           feeCalculationRequest.getRepresentationOrderDate();
-      case ADVOCACY_APPEALS_REVIEWS ->  getFeeClaimStartDateAdvocacyAppealsReviews(feeCalculationRequest);
+      case ADVOCACY_APPEALS_REVIEWS -> getFeeClaimStartDateAdvocacyAppealsReviews(feeCalculationRequest);
       default -> feeCalculationRequest.getStartDate();
     };
   }
@@ -135,7 +135,7 @@ public final class FeeCalculationUtil {
     if (feeCalculationRequest.getFeeCode().equals("PROH") && nonNull(feeCalculationRequest.getRepresentationOrderDate())) {
       log.info("Determining fee start date for PROH, using Representation Order Date");
       return feeCalculationRequest.getRepresentationOrderDate();
-    } else  {
+    } else {
       log.info("Determining fee start date, using Unique File Number");
       return DateUtil.toLocalDate(Objects.requireNonNull(feeCalculationRequest.getUniqueFileNumber()));
     }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/StandardFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/StandardFixedFeeCalculatorTest.java
@@ -59,9 +59,9 @@ class StandardFixedFeeCalculatorTest {
     Set<CategoryType> categories = standardFixedFeeCalculator.getSupportedCategories();
 
     assertThat(categories).isNotNull();
-    assertThat(categories).hasSize(13); // make sure the total count matches
+    assertThat(categories).hasSize(12); // make sure the total count matches
     assertThat(categories).containsExactlyInAnyOrder(
-        CategoryType.ASSOCIATED_CIVIL, CategoryType.CLAIMS_PUBLIC_AUTHORITIES,
+        CategoryType.CLAIMS_PUBLIC_AUTHORITIES,
         CategoryType.CLINICAL_NEGLIGENCE, CategoryType.COMMUNITY_CARE,
         CategoryType.DEBT, CategoryType.EDUCATION, CategoryType.FAMILY,
         CategoryType.HOUSING, CategoryType.HOUSING_HLPAS,

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
@@ -1,0 +1,61 @@
+package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ASSOCIATED_CIVIL;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
+import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AssociatedCivilFixedFeeCalculatorTest {
+
+  @InjectMocks
+  AssociatedCivilFixedFeeCalculator associatedCivilFixedFeeCalculator;
+
+  @Test
+  void calculate_shouldReturnFeeCalculationResponse() {
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode("ASMS")
+        .claimId("claim_123")
+        .uniqueFileNumber("020416/001")
+        .vatIndicator(true)
+        .netDisbursementAmount(100.11)
+        .disbursementVatAmount(20.22)
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("ASMS")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("ASSOC_FS2016").build())
+        .fixedFee(new BigDecimal("50.00"))
+        .categoryType(ASSOCIATED_CIVIL)
+        .build();
+
+    FeeCalculationResponse result = associatedCivilFixedFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getFeeCode()).isEqualTo("ASMS");
+    assertThat(result.getClaimId()).isEqualTo("claim_123");
+    assertThat(result.getSchemeId()).isEqualTo("ASSOC_FS2016");
+    assertThat(result.getEscapeCaseFlag()).isFalse();
+
+    FeeCalculation feeCalculation = result.getFeeCalculation();
+    assertThat(feeCalculation).isNotNull();
+    assertThat(feeCalculation.getTotalAmount()).isEqualTo(180.33);
+    assertThat(feeCalculation.getVatIndicator()).isTrue();
+    assertThat(feeCalculation.getVatRateApplied()).isEqualTo(20.0);
+    assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(10.0);
+    assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
+    assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
+    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.22);
+    assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(50);
+  }
+}

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
@@ -2,11 +2,12 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ASSOCIATED_CIVIL;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
@@ -14,6 +15,7 @@ import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class AssociatedCivilFixedFeeCalculatorTest {
@@ -21,41 +23,94 @@ class AssociatedCivilFixedFeeCalculatorTest {
   @InjectMocks
   AssociatedCivilFixedFeeCalculator associatedCivilFixedFeeCalculator;
 
-  @Test
-  void calculate_shouldReturnFeeCalculationResponse() {
-    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+  @ParameterizedTest
+  @CsvSource({
+      "false, 10.00, 20.00, 170.33, 0",  // Under escape threshold (No VAT)
+      "true, 10.00, 20.00, 180.33, 10.00",  // Under escape threshold limit (VAT applied)
+      "false, 80.00, 20.00, 170.33, 0", // Equal to escape threshold limit (No VAT)
+      "true, 80.00, 20.00, 180.33, 10.00" // Equal to escape threshold limit (VAT applied)
+  })
+  void calculate_shouldReturnFeeCalculationResponse(boolean vatIndicator, double netTravelCosts,
+                                                    double netWaitingCosts, double expectedTotal,
+                                                    double expectedVat) {
+
+    FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netTravelCosts, netWaitingCosts);
+    FeeEntity feeEntity = buildFeeEntity();
+
+    FeeCalculationResponse result = associatedCivilFixedFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertFeeCalculation(result, expectedTotal,vatIndicator, netTravelCosts, netWaitingCosts, expectedVat, false);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "false, 90.00, 20.00, 170.33, 0", // Over escape threshold limit (No VAT)
+      "true, 90.00, 20.00, 180.33, 10.00" // Over escape threshold limit (VAT applied)
+  })
+  void calculate_shouldReturnFeeCalculationResponseWithWarning(boolean vatIndicator, double netTravelCosts,
+                                                               double netWaitingCosts, double expectedTotal,
+                                                               double expectedVat) {
+
+    FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netTravelCosts, netWaitingCosts);
+    FeeEntity feeEntity = buildFeeEntity();
+
+    FeeCalculationResponse result = associatedCivilFixedFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertFeeCalculation(result, expectedTotal,vatIndicator, netTravelCosts, netWaitingCosts, expectedVat, true);
+
+    ValidationMessagesInner validationMessage = ValidationMessagesInner.builder()
+        .message("123")
+        .type(WARNING)
+        .build();
+
+    assertThat(result.getValidationMessages()).size().isEqualTo(1);
+    assertThat(result.getValidationMessages().getFirst()).isEqualTo(validationMessage);
+  }
+
+  private FeeCalculationRequest buildRequest(boolean vatIndicator, double netTravelCosts,
+                                             double netWaitingCosts) {
+    return FeeCalculationRequest.builder()
         .feeCode("ASMS")
         .claimId("claim_123")
         .uniqueFileNumber("020416/001")
-        .vatIndicator(true)
+        .vatIndicator(vatIndicator)
+        .netProfitCosts(400.00)
+        .netTravelCosts(netTravelCosts)
+        .netWaitingCosts(netWaitingCosts)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
         .build();
+  }
 
-    FeeEntity feeEntity = FeeEntity.builder()
+  private FeeEntity buildFeeEntity() {
+    return FeeEntity.builder()
         .feeCode("ASMS")
         .feeScheme(FeeSchemesEntity.builder().schemeCode("ASSOC_FS2016").build())
         .fixedFee(new BigDecimal("50.00"))
         .categoryType(ASSOCIATED_CIVIL)
+        .escapeThresholdLimit(new BigDecimal("500.00"))
         .build();
+  }
 
-    FeeCalculationResponse result = associatedCivilFixedFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+  private void assertFeeCalculation(FeeCalculationResponse response, double total, boolean vatIndicator,
+                                    double netTravelCosts, double netWaitingCosts, double vat, boolean escapeFlag) {
+    assertThat(response).isNotNull();
+    assertThat(response.getFeeCode()).isEqualTo("ASMS");
+    assertThat(response.getClaimId()).isEqualTo("claim_123");
+    assertThat(response.getSchemeId()).isEqualTo("ASSOC_FS2016");
+    assertThat(response.getEscapeCaseFlag()).isEqualTo(escapeFlag);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getFeeCode()).isEqualTo("ASMS");
-    assertThat(result.getClaimId()).isEqualTo("claim_123");
-    assertThat(result.getSchemeId()).isEqualTo("ASSOC_FS2016");
-    assertThat(result.getEscapeCaseFlag()).isFalse();
-
-    FeeCalculation feeCalculation = result.getFeeCalculation();
+    FeeCalculation feeCalculation = response.getFeeCalculation();
     assertThat(feeCalculation).isNotNull();
-    assertThat(feeCalculation.getTotalAmount()).isEqualTo(180.33);
-    assertThat(feeCalculation.getVatIndicator()).isTrue();
+    assertThat(feeCalculation.getTotalAmount()).isEqualTo(total);
+    assertThat(feeCalculation.getVatIndicator()).isEqualTo(vatIndicator);
     assertThat(feeCalculation.getVatRateApplied()).isEqualTo(20.0);
-    assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(10.0);
+    assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(vat);
     assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
     assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
     assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.22);
+    assertThat(feeCalculation.getNetTravelCostsAmount()).isEqualTo(netTravelCosts);
+    assertThat(feeCalculation.getNetWaitingCostsAmount()).isEqualTo(netWaitingCosts);
     assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(50);
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MagsYouthCourtFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MagsYouthCourtFixedFeeCalculatorTest.java
@@ -233,7 +233,7 @@ class MagsYouthCourtFixedFeeCalculatorTest {
           .requestedNetDisbursementAmount(request.getNetDisbursementAmount())
           .disbursementVatAmount(request.getDisbursementVatAmount())
           .netTravelCostsAmount(expectedNetTravel)
-          .netWaitingCosts(expectedNetWaiting)
+          .netWaitingCostsAmount(expectedNetWaiting)
           .fixedFeeAmount(fixedFee)
           .calculatedVatAmount(expectedVat)
           .build();

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
@@ -112,7 +112,7 @@ class AdvocacyAppealsReviewsHourlyRateCalculatorTest {
         .netProfitCostsAmount(requestedProfitCosts)
         .requestedNetProfitCostsAmount(requestedProfitCosts)
         .netTravelCostsAmount(requestedTravelCosts)
-        .netWaitingCosts(requestedWaitingCosts)
+        .netWaitingCostsAmount(requestedWaitingCosts)
         .build();
 
     ValidationMessagesInner warning = ValidationMessagesInner.builder().message(WARNING_CODE_DESCRIPTION).type(WARNING).build();

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
@@ -79,7 +79,6 @@ class DiscriminationHourlyRateCalculatorTest {
     assertThat(result).isEqualTo(Set.of(DISCRIMINATION));
   }
 
-
   private FeeCalculationRequest buildRequest(boolean vatIndicator, double netProfitCosts,
                                              double costOfCounsel) {
     return FeeCalculationRequest.builder()


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-193)

-   Moved fee calculaton to separate class - AssociatedCivilFixedFeeCalculator and added escape logic
-   Renamed netWaitingCosts to netWaitingCostsAmount for consistency

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
