### PR TITLE
LFSP-396 update service name back to use chart.name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,13 +74,12 @@ jobs:
       environment: uat
     secrets: inherit
 
-  deploy-staging:
-    needs: deploy-uat
-    uses: ./.github/workflows/_deploy-to-env.yml
-    with:
-      environment: staging
-    secrets: inherit
-
+#  deploy-staging:
+#    needs: deploy-uat
+#    uses: ./.github/workflows/_deploy-to-env.yml
+#    with:
+#      environment: staging
+#    secrets: inherit
 #
 #  deploy-prod:
 #    needs: deploy-staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and deploy after PR merged
 on:
   push:
     branches:
-      - main
+      - LFSP-396-update-service-name
   workflow_dispatch:
 
 permissions:
@@ -67,26 +67,26 @@ jobs:
       environment: dev
     secrets: inherit
 
-  deploy-uat:
-    needs: deploy-dev
-    uses: ./.github/workflows/_deploy-to-env.yml
-    with:
-      environment: uat
-    secrets: inherit
-
-  deploy-staging:
-    needs: deploy-uat
-    uses: ./.github/workflows/_deploy-to-env.yml
-    with:
-      environment: staging
-    secrets: inherit
-
-  deploy-prod:
-    needs: deploy-staging
-    uses: ./.github/workflows/_deploy-to-env.yml
-    with:
-      environment: prod
-    secrets: inherit
+#  deploy-uat:
+#    needs: deploy-dev
+#    uses: ./.github/workflows/_deploy-to-env.yml
+#    with:
+#      environment: uat
+#    secrets: inherit
+#
+#  deploy-staging:
+#    needs: deploy-uat
+#    uses: ./.github/workflows/_deploy-to-env.yml
+#    with:
+#      environment: staging
+#    secrets: inherit
+#
+#  deploy-prod:
+#    needs: deploy-staging
+#    uses: ./.github/workflows/_deploy-to-env.yml
+#    with:
+#      environment: prod
+#    secrets: inherit
 
   vulnerability-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,19 +67,20 @@ jobs:
       environment: dev
     secrets: inherit
 
-#  deploy-uat:
-#    needs: deploy-dev
-#    uses: ./.github/workflows/_deploy-to-env.yml
-#    with:
-#      environment: uat
-#    secrets: inherit
-#
-#  deploy-staging:
-#    needs: deploy-uat
-#    uses: ./.github/workflows/_deploy-to-env.yml
-#    with:
-#      environment: staging
-#    secrets: inherit
+  deploy-uat:
+    needs: deploy-dev
+    uses: ./.github/workflows/_deploy-to-env.yml
+    with:
+      environment: uat
+    secrets: inherit
+
+  deploy-staging:
+    needs: deploy-uat
+    uses: ./.github/workflows/_deploy-to-env.yml
+    with:
+      environment: staging
+    secrets: inherit
+
 #
 #  deploy-prod:
 #    needs: deploy-staging

--- a/helm_deploy/laa-fee-scheme-api/templates/_helpers.tpl
+++ b/helm_deploy/laa-fee-scheme-api/templates/_helpers.tpl
@@ -34,3 +34,14 @@ app.kubernetes.io/metadata.name: {{ .Release.Name }}
 app.kubernetes.io/name: {{ include "laa-fee-scheme-api.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Use release name if release name starts with "laa-fee-scheme-api-pr" else use chart name
+*/}}
+{{- define "laa-fee-scheme-api.serviceName" -}}
+{{- if hasPrefix "laa-fee-scheme-api-pr" .Release.Name }}
+{{- printf "%s-service" .Release.Name }}
+{{- else }}
+{{- printf "%s-service" .Chart.Name }}
+{{- end }}
+{{- end }}

--- a/helm_deploy/laa-fee-scheme-api/templates/hpa.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/hpa.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: "{{ .Chart.Name }}-deployment"
+    name: "{{ .Release.Name }}-deployment"
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/helm_deploy/laa-fee-scheme-api/templates/ingress.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
             pathType: "ImplementationSpecific"
             backend:
               service:
-                name: { { include "laa-fee-scheme-api.serviceName" $ } }
+                name: {{ include "laa-fee-scheme-api.serviceName" $ }}
                 port:
                   number: {{ $.Values.service.port }}
   {{- end }}

--- a/helm_deploy/laa-fee-scheme-api/templates/ingress.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
             pathType: "ImplementationSpecific"
             backend:
               service:
-                name: {{ $.Chart.Name }}-service
+                name: { { include "laa-fee-scheme-api.serviceName" $ } }
                 port:
                   number: {{ $.Values.service.port }}
   {{- end }}

--- a/helm_deploy/laa-fee-scheme-api/templates/prometheus-rules.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/prometheus-rules.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus: prometheus-operator
     role: alert-rules
     release: prometheus-operator
-  name: prometheus-custom-rules-{{ .Release.Name }}
+  name: prometheus-custom-rules-{{ .Chart.Name }}
 spec:
   groups:
   - name: application-rules

--- a/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
@@ -1,10 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "laa-fee-scheme-api.serviceName" . }}
+  name: "{{ .Release.Name }}-service"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "laa-fee-scheme-api.labels" . | nindent 4 }}
+    legacy: "true"
+  annotations:
+    description: "release.name service name for backward compatibility, will be removed after migration"
 spec:
   ports:
     - name: http

--- a/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
@@ -1,3 +1,4 @@
+{{- if not (hasPrefix "laa-fee-scheme-api-pr" .Release.Name) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "laa-fee-scheme-api.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
@@ -1,4 +1,5 @@
 {{- if not (hasPrefix "laa-fee-scheme-api-pr" .Release.Name) }}
+{{- if ne .Release.Name .Chart.Name }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,4 +22,5 @@ spec:
       protocol: TCP
   selector:
     {{- include "laa-fee-scheme-api.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/scheme-api/build.gradle
+++ b/scheme-api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.21.2'
-    implementation 'tools.jackson.core:jackson-core:3.1.0'
+    implementation 'tools.jackson.core:jackson-core:3.1.1'
 }
 
 sourceSets.main.java.srcDirs += ['generated/src/main/java']

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 
     implementation project(':scheme-api')
 
+    implementation("tools.jackson.core:jackson-core:3.1.1")
+    implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.21")
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -73,6 +73,15 @@ dependencyManagement {
 }
 
 dependencies {
+    constraints {
+        implementation("tools.jackson.core:jackson-core:3.1.1") {
+            because "Fix Snyk vulnerability"
+        }
+        implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.21") {
+            because "Fix Snyk vulnerability"
+        }
+    }
+
     implementation project(':scheme-api')
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/LFSP-396

Update to have preview deploys use release.name, DEV, UAT, PROD to use use chart.name

service-legacy/yaml to allow for safe migration back to chart.name from release.name

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
