### PR TITLE
LFSP-404 Pinned all other git hashes that were missed from actions

### DIFF
--- a/.github/workflows/_deploy-to-env.yml
+++ b/.github/workflows/_deploy-to-env.yml
@@ -41,14 +41,14 @@ jobs:
 
       - name: Login to AWS ECR container repo
         id: login-ecr
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           ecr_region: ${{ vars.ECR_REGION }}
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           role-session-name: deployment
 
       - name: Authenticate with Kubernetes cluster in Cloud Platform
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           kube-cert: ${{ secrets.KUBE_CERT }}
           kube-token: ${{ secrets.KUBE_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
           echo "values_file=$VALUES_FILE" >> $GITHUB_OUTPUT
 
       - name: Helm Deploy
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/helm-deploy@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/helm-deploy@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           k8s_namespace: ${{ secrets.KUBE_NAMESPACE }}
           helm_release_name: ${{ steps.target.outputs.release }}

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Authenticate with Kubernetes cluster
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           kube-cert: ${{ secrets.KUBE_CERT }}
           kube-token: ${{ secrets.KUBE_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
 
       # ECR cleanup
       - name: Login to ECR
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           ecr_region: ${{ vars.ECR_REGION }}
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -35,7 +35,7 @@ jobs:
       - run: ./gradlew clean build
 
       - name: Login to ECR
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         id: auth
         with:
           ecr_region: ${{ vars.ECR_REGION }}
@@ -43,7 +43,7 @@ jobs:
           role-session-name: preview
 
       - name: Build and push preview image
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           dockerfile_path: ./Dockerfile
           image_registry: ${{ steps.auth.outputs.image_registry }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to AWS ECR container repo
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         id: auth
         with:
           ecr_region: ${{ vars.ECR_REGION }}
@@ -53,7 +53,7 @@ jobs:
           role-session-name: deployment
 
       - name: Build and Push
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main
         with:
           dockerfile_path: ./Dockerfile
           image_registry: ${{ steps.auth.outputs.image_registry }}
@@ -106,7 +106,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Setup Snyk
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # master
 
       - name: Run Snyk to check app for vulnerabilities
         run: snyk monitor --severity-threshold=high
@@ -123,6 +123,6 @@ jobs:
           sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk-app.sarif
 
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: snyk-app.sarif

--- a/.github/workflows/snyk-vulnerability-scans.yml
+++ b/.github/workflows/snyk-vulnerability-scans.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Run Snyk to check app for vulnerabilities
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle@9adf32b1121593767fc3c057af55b55db032dc04 # master
         with:
           command: code test
           args: --severity-threshold=high
@@ -53,7 +53,7 @@ jobs:
         run: docker build -t laa-fee-scheme-api:scan .
 
       - name: Run Snyk to check Docker image for vulnerabilities
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
         with:
           image: laa-fee-scheme-api:scan
           args: --file=Dockerfile --severity-threshold=high

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -75,6 +75,10 @@ dependencyManagement {
 dependencies {
     implementation project(':scheme-api')
 
+    // To be removed as apart of LSFP-403
+    implementation("tools.jackson.core:jackson-core:3.1.1")
+    implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.21")
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-404)

To improve security and reduce potential supply chain risks, all GitHub Actions should be pinned to specific commit SHAs instead of version tags.

This was largely done in LFSP-398: FSP- Github Actions version updates with SHA. 

But there are still a few left. Specifically, I noticed several unpinned uses of ministryofjustice/laa-reusable-github-actions, as well as repos from snyk, github, and at least one other. 

These all have been pinned.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
