### PR TITLE
LFSP-423 fix single running pod in production instead of dual running after service name changes

### DIFF
--- a/helm_deploy/laa-fee-scheme-api/templates/_helpers.tpl
+++ b/helm_deploy/laa-fee-scheme-api/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Use release name if release name starts with "laa-fee-scheme-api-pr" else use chart name
 */}}
 {{- define "laa-fee-scheme-api.serviceName" -}}
-{{- if hasPrefix "laa-fee-scheme-api-pr" .Release.Name }}
+{{- if hasPrefix "laa-fee-scheme-api-pr-" .Release.Name }}
 {{- printf "%s-service" .Release.Name }}
 {{- else }}
 {{- printf "%s-service" .Chart.Name }}

--- a/helm_deploy/laa-fee-scheme-api/templates/configmap.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus (.Values.prometheus.enabled | default false) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm_deploy/laa-fee-scheme-api/templates/prometheus-rules.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/prometheus-rules.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus (.Values.prometheus.enabled | default false) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
+++ b/helm_deploy/laa-fee-scheme-api/templates/service-legacy.yaml
@@ -1,5 +1,4 @@
-{{- if not (hasPrefix "laa-fee-scheme-api-pr" .Release.Name) }}
-{{- if ne .Release.Name .Chart.Name }}
+{{- if .Values.legacyService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,5 +21,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "laa-fee-scheme-api.selectorLabels" . | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/helm_deploy/laa-fee-scheme-api/values-dev-preview.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-dev-preview.yaml
@@ -34,3 +34,6 @@ application:
 
 prometheus:
   enabled: false
+
+legacyService:
+  enabled: true

--- a/helm_deploy/laa-fee-scheme-api/values-dev-preview.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-dev-preview.yaml
@@ -36,4 +36,4 @@ prometheus:
   enabled: false
 
 legacyService:
-  enabled: true
+  enabled: false

--- a/helm_deploy/laa-fee-scheme-api/values-dev.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-dev.yaml
@@ -37,3 +37,6 @@ prometheus:
   dashboardUrl: https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-fee-scheme-api-dev-dashboard
   severity: laa-fee-scheme-api-dev
   zeroPodsInterval: 15m
+
+legacyService:
+  enabled: true

--- a/helm_deploy/laa-fee-scheme-api/values-prod.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-prod.yaml
@@ -44,3 +44,6 @@ prometheus:
   dashboardUrl: https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-fee-scheme-api-prod-dashboard
   severity: laa-fee-scheme-api-prod
   zeroPodsInterval: 1m
+
+legacyService:
+  enabled: true

--- a/helm_deploy/laa-fee-scheme-api/values-staging.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-staging.yaml
@@ -44,3 +44,6 @@ prometheus:
   dashboardUrl: https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-fee-scheme-api-staging-dashboard
   severity: laa-fee-scheme-api-staging
   zeroPodsInterval: 1m
+
+legacyService:
+  enabled: true

--- a/helm_deploy/laa-fee-scheme-api/values-uat.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values-uat.yaml
@@ -41,3 +41,6 @@ prometheus:
   dashboardUrl: https://grafana.live.cloud-platform.service.justice.gov.uk/d/laa-fee-scheme-api-uat-dashboard
   severity: laa-fee-scheme-api-uat
   zeroPodsInterval: 1m
+
+legacyService:
+  enabled: true

--- a/helm_deploy/laa-fee-scheme-api/values.yaml
+++ b/helm_deploy/laa-fee-scheme-api/values.yaml
@@ -85,3 +85,6 @@ spring:
 application:
   logging:
     level: INFO
+
+legacyService:
+  enabled: true

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
 
-    runtimeOnly 'org.postgresql:postgresql:42.7.10'
+    runtimeOnly 'org.postgresql:postgresql:42.7.11'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-restclient'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-423)

Updated helm files to use the proposed solution of having two services. Service legacy now uses new logic to determine if it should be used. Fixed helper to use correct prefix logic to check if it should render for pr/prod. Updated prometheus rules to be more absolute in defaulting to false if values.prometheus.enabled isnt set. 

Updated postgres security issue identified by snyk.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
