### PR TITLE
LFSP-477 Add new field "requested disbursement VAT amount" in Fee Calculation Response

### DIFF
--- a/scheme-api/open-api-specification.yml
+++ b/scheme-api/open-api-specification.yml
@@ -334,6 +334,10 @@ components:
           type: number
           format: double
           description: "The disbursement Vat amount calculated to be added."
+        requestedDisbursementVatAmount:
+          type: number
+          format: double
+          description: "The requested disbursement Vat amount."
         hourlyTotalAmount:
           type: number
           format: double


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-477)

Currently, in the fee calculation response, we return the requested net disbursement amount alongside the calculated values.

As discussed and approved by Mike Hooper, we also need to return the requested disbursement VAT amount in the response, particularly for scenarios where the capped disbursement VAT amount is used in the total amount calculation and returned in the response.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
