### PR TITLE
LFSP-469 run pitest per-PR in CI and upload HTML report

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -21,6 +21,34 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  pitest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'corretto'
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c  # v5
+
+      - name: Run pitest (mutation testing)
+        run: ./gradlew :scheme-service:pitest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload pitest HTML report
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        with:
+          name: pitest-report
+          path: scheme-service/build/reports/pitest
+          retention-days: 14
+
   snyk-vulnerability-scan:
     uses: ./.github/workflows/snyk-vulnerability-scans.yml
     secrets:

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'io.freefair.lombok' version '9.5.0'
     id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
     id "io.sentry.jvm.gradle" version "6.10.0"
+    id 'info.solidsoft.pitest'
 }
 
 def versions = [
@@ -44,6 +45,25 @@ jacocoTestCoverageVerification {
             }
         }
     }
+}
+
+pitest {
+    pitestVersion = '1.23.1'
+    junit5PluginVersion = '1.2.3'
+
+    targetClasses = ['uk.gov.justice.laa.fee.scheme.*']
+    targetTests = ['uk.gov.justice.laa.fee.scheme.*Test']
+    excludedClasses = [
+        'uk.gov.justice.laa.fee.scheme.FeeSchemeApplication',
+        'uk.gov.justice.laa.fee.scheme.config.*',
+        'uk.gov.justice.laa.fee.scheme.enums.*',
+        'uk.gov.justice.laa.fee.scheme.entity.*'
+    ]
+
+    outputFormats = ['HTML', 'XML']
+    timestampedReports = false
+    threads = 4
+    failWhenNoMutations = false
 }
 
 ['checkstyleTest', 'checkstyleIntegrationTest'].each {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
 
     plugins {
         id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.2.12'
+        id 'info.solidsoft.pitest' version '1.19.0'
     }
 }
 


### PR DESCRIPTION
## What

[LFSP-469](https://dsdmoj.atlassian.net/browse/LFSP-469)

Runs pitest in CI per-PR and uploads the HTML report as a downloadable artefact, so mutation survivors surface on every PR. Builds on the LFSP-422 spike; its pitest config is folded in here since it wasn't on main yet. No score threshold yet, so the build won't fail on it.

Pitest CI run time: 2m 23s mutation step, 2m 45s full job.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LFSP-469]: https://dsdmoj.atlassian.net/browse/LFSP-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ