### PR TITLE
LFSP-532 files updated to use case concluded date for vat rate retrieval (Civil and Crime categories)

### DIFF
--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationDisbursementOnlyIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationDisbursementOnlyIntegrationTest.java
@@ -16,7 +16,8 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
           "claimId": "claim_123",
           "startDate": "2025-02-01",
           "netDisbursementAmount": 123.38,
-          "disbursementVatAmount": 24.67
+          "disbursementVatAmount": 24.67,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -45,7 +46,8 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
           "claimId": "claim_123",
           "startDate": "2013-04-01",
           "netDisbursementAmount": 55.35,
-          "disbursementVatAmount": 11.07
+          "disbursementVatAmount": 11.07,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -75,7 +77,8 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
           "claimId": "claim_123",
           "startDate": "2022-07-29",
           "netDisbursementAmount": 1200.0,
-          "disbursementVatAmount": 150.0
+          "disbursementVatAmount": 150.0,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
@@ -21,7 +21,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netWaitingCosts": 11.5,
           "netDisbursementAmount": 55.35,
           "disbursementVatAmount": 11.07,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-06-06"
         }
         """;
 
@@ -67,7 +68,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "representationOrderDate": "%s",
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, representationOrderDate);
 
@@ -110,7 +112,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "uniqueFileNumber": "%s",
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, uniqueFileNumber);
 
@@ -141,7 +144,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
           "londonRate": true,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -245,7 +249,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "disbursementVatAmount": 20.12,
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
-          "jrFormFilling": 50.00
+          "jrFormFilling": 50.00,
+          "caseConcludedDate": "2026-02-01"
         """.formatted(feeCode, startDate);
     request = (boltOn != null) ? request + ", \"boltOns\": { \"boltOn%s\": 1 }}".formatted(boltOn) : request + "}";
 
@@ -262,7 +267,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netDisbursementAmount": 100.21,
           "disbursementVatAmount": 20.12,
           "vatIndicator": true,
-          "numberOfMediationSessions": 1
+          "numberOfMediationSessions": 1,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -298,7 +304,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "vatIndicator": true,
           "boltOns": {
             "boltOnAdjournedHearing": 3.00
-          }
+          },
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -338,7 +345,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netProfitCosts": 239.06,
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -388,7 +396,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netProfitCosts": 239.06,
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode);
 
@@ -422,7 +431,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "uniqueFileNumber": "12122019/242",
           "policeStationId": "NE001",
           "policeStationSchemeId": "1001",
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -457,7 +467,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "uniqueFileNumber": "%s",
           "policeStationId": "NE001",
           "policeStationSchemeId": "1001",
-          "vatIndicator": false
+          "vatIndicator": false,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(ufn);
 
@@ -508,7 +519,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "netWaitingCosts": 200,
           "netDisbursementAmount": 100,
           "disbursementVatAmount": 20,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, ufn);
 
@@ -552,7 +564,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "uniqueFileNumber": "%s",
           "representationOrderDate": "%s",
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, uniqueFileNumber, representationOrderDate);
 
@@ -598,7 +611,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "disbursementVatAmount": 24.67,
           "vatIndicator": true,
           "netWaitingCosts": %s,
-          "netTravelCosts": %s
+          "netTravelCosts": %s,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, representationOrderDate, netWaitingCosts, netTravelCosts);
 

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
@@ -15,13 +15,13 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
         {
           "feeCode": "PROD",
           "claimId": "claim_123",
-          "caseConcludedDate": "2024-12-06",
           "netProfitCosts": 500,
           "netDisbursementAmount": 100,
           "disbursementVatAmount": 20,
           "vatIndicator": true,
           "netTravelCosts": 50,
-          "netWaitingCosts": 50
+          "netWaitingCosts": 50,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -77,7 +77,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "disbursementVatAmount": 10,
           "vatIndicator": true,
           "netTravelCosts": 50,
-          "netWaitingCosts": 50
+          "netWaitingCosts": 50,
+          "caseConcludedDate": "2020-12-06"
         }
         """.formatted(feeCode, uniqueFileNumber, netProfitCostsAmount);
 
@@ -133,7 +134,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "disbursementVatAmount": 10,
           "vatIndicator": true,
           "netTravelCosts": 50,
-          "netWaitingCosts": 50
+          "netWaitingCosts": 50,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, representationOrderDate, uniqueFileNumber, netProfitCostsAmount);
 
@@ -172,7 +174,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "netCostOfCounsel": 79.19,
           "netDisbursementAmount": 100.21,
           "disbursementVatAmount": 20.12,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -216,7 +219,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "netCostOfCounsel": 356.90,
           "netDisbursementAmount": 125.70,
           "disbursementVatAmount": 25.14,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode);
 
@@ -267,7 +271,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
               "boltOnCmrhTelephone": 1,
               "boltOnSubstantiveHearing": true
           },
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode);
 
@@ -322,7 +327,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": %s,
           "netDisbursementAmount": 100,
           "disbursementVatAmount": 20,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, netProfitCosts);
 
@@ -362,7 +368,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "disbursementVatAmount": 20.15,
           "netTravelCosts": 20.0,
           "netWaitingCosts": 10.0,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -408,7 +415,8 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "disbursementVatAmount": 2.1,
           "netTravelCosts": 11.35,
           "netWaitingCosts": 12.22,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """.formatted(feeCode, ufn);
 

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
@@ -723,7 +723,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netDisbursementAmount": 55.35,
           "disbursementVatAmount": 11.07,
           "londonRate": false,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2024-12-06"
         }
         """;
 
@@ -789,7 +790,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
           "jrFormFilling": 50.00,
-          "netProfitCosts": "%s"
+          "netProfitCosts": "%s",
+          "caseConcludedDate": "2026-02-01"
         }
         """
             .formatted(feeCode, requestedDisbursementAmount, netProfitCosts);
@@ -848,7 +850,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 1160.89,
           "netDisbursementAmount": 825.70,
           "disbursementVatAmount": 25.14,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -894,7 +897,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 1160.89,
           "netDisbursementAmount": 825.70,
           "disbursementVatAmount": 25.14,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -945,7 +949,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 1160.89,
           "netDisbursementAmount": 825.70,
           "disbursementVatAmount": 25.14,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1000,7 +1005,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           },
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
-          "jrFormFilling": 50.00
+          "jrFormFilling": 50.00,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1065,7 +1071,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "claimId": "claim_123",
           "startDate": "2021-09-30",
           "netDisbursementAmount": 2000,
-          "disbursementVatAmount": 400
+          "disbursementVatAmount": 400,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1109,7 +1116,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netWaitingCosts": 32,
           "netDisbursementAmount": 600,
           "disbursementVatAmount": 120,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1156,7 +1164,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netWaitingCosts": 10,
           "netDisbursementAmount": 600,
           "disbursementVatAmount": 120,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1206,7 +1215,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netWaitingCosts": 70.0,
           "netDisbursementAmount": 55.35,
           "disbursementVatAmount": 11.07,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1253,7 +1263,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netWaitingCosts": 70.0,
           "netDisbursementAmount": 55.35,
           "disbursementVatAmount": 11.07,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1317,7 +1328,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netDisbursementAmount": 100,
           "disbursementVatAmount": 20,
           "vatIndicator": true,
-          "netWaitingCosts": 150
+          "netWaitingCosts": 150,
+          "caseConcludedDate": "2026-02-01"
         }
         """
             .formatted(feeCode);
@@ -1375,7 +1387,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "vatIndicator": true,
           "boltOns": {
               "boltOnAdjournedHearing": 1
-          }
+          },
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 
@@ -1444,7 +1457,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 1000.0,
           "netDisbursementAmount": 123.38,
           "disbursementVatAmount": 24.67,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """
             .formatted(feeCode);
@@ -1498,7 +1512,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netCostOfCounsel": 79.19,
           "netDisbursementAmount": 100.21,
           "disbursementVatAmount": 20.12,
-          "vatIndicator": true
+          "vatIndicator": true,
+          "caseConcludedDate": "2026-02-01"
         }
         """;
 

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
@@ -5,7 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -60,9 +60,9 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(CategoryType.ASSOCIATED_CIVIL, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Get disbursements

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
@@ -5,7 +5,6 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -13,7 +12,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -60,9 +58,8 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Get disbursements
@@ -92,7 +89,7 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculator.java
@@ -3,7 +3,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
@@ -46,9 +46,9 @@ public class EarlyCoverFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(feeEntity.getCategoryType(), feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Calculate total amount

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculator.java
@@ -3,13 +3,11 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,9 +44,8 @@ public class EarlyCoverFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Calculate total amount
@@ -56,7 +53,7 @@ public class EarlyCoverFixedFeeCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .fixedFeeAmount(toDouble(fixedFeeAmount))

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
@@ -8,6 +8,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
@@ -107,9 +108,9 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .add(toBigDecimal(boltOnFeeDetails.getBoltOnTotalFeeAmount()));
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getStartDate();
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Calculate total amount

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
@@ -8,7 +8,6 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
@@ -18,7 +17,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -108,9 +106,8 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .add(toBigDecimal(boltOnFeeDetails.getBoltOnTotalFeeAmount()));
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Calculate total amount
@@ -125,7 +122,7 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(netDisbursementAmount) : null)

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculator.java
@@ -83,7 +83,10 @@ public class MediationFixedFeeCalculator implements FeeCalculator {
 
     log.info("Get fields from fee calculation request");
 
+
+    // TODO: Revisit the logic below when ticket LFSP-533 is taken up for development.
     // Calculate VAT if applicable
+
     LocalDate claimStartDate = getFeeClaimStartDate(feeEntity.getCategoryType(), feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
     BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
@@ -7,7 +7,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -65,9 +65,9 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
         .add(toBigDecimal(boltOnFeeDetails.getBoltOnTotalFeeAmount()));
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(feeEntity.getCategoryType(), feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Get disbursements

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
@@ -7,7 +7,6 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -15,7 +14,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -65,9 +63,8 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
         .add(toBigDecimal(boltOnFeeDetails.getBoltOnTotalFeeAmount()));
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Get disbursements
@@ -87,7 +84,7 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
@@ -7,7 +7,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -85,9 +85,9 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(policeStationFeesEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(CategoryType.POLICE_STATION, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Get disbursements
@@ -142,9 +142,9 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = feeEntity.getFixedFee();
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(CategoryType.POLICE_STATION, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
@@ -7,7 +7,6 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -15,7 +14,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -85,9 +83,8 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(policeStationFeesEntity.getFixedFee());
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Get disbursements
@@ -119,7 +116,7 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
@@ -142,9 +139,8 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
     BigDecimal fixedFeeAmount = feeEntity.getFixedFee();
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -51,9 +52,9 @@ public class UndesignatedCourtFixedFeeCalculator implements FeeCalculator {
         .add(requestedWaitingCosts);
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getRepresentationOrderDate();
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Get disbursements

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
@@ -3,14 +3,12 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,9 +50,7 @@ public class UndesignatedCourtFixedFeeCalculator implements FeeCalculator {
         .add(requestedWaitingCosts);
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Get disbursements
@@ -67,7 +63,7 @@ public class UndesignatedCourtFixedFeeCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
@@ -2,7 +2,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard;
 
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -42,12 +42,12 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
     //Step 1: get Fixed Fee Amount
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
-    //Step 2: get Start Date
-    LocalDate claimStartDate = getFeeClaimStartDate(feeEntity.getCategoryType(), feeCalculationRequest);
+    //Step 2: get case Conclusion Date to calculate VAT if applicable
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
 
     //Step 3: get VAT Rate
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
 
     //Step 4: Calculate VAT Amount
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
@@ -2,14 +2,12 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard;
 
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,12 +40,8 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
     //Step 1: get Fixed Fee Amount
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
-    //Step 2: get case Conclusion Date to calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-
-    //Step 3: get VAT Rate
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    //Step 2: get VAT Rate
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
 
     //Step 4: Calculate VAT Amount
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
@@ -70,7 +64,7 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
     //Step 8: build FeeCalculation
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(toDoubleOrNull(netDisbursementAmount))

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
@@ -43,25 +43,25 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
     //Step 2: get VAT Rate
     BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
 
-    //Step 4: Calculate VAT Amount
+    //Step 3: Calculate VAT Amount
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
-    //Step 5: get Disbursements
+    //Step 4: get Disbursements
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
     BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
 
-    //Step 6: calculate Total Amount
+    //Step 5: calculate Total Amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount, netDisbursementAmount,
         disbursementVatAmount);
 
-    //Step 7: check if escaped, if eligible
+    //Step 6: check if escaped, if eligible
     List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     boolean isEscaped = false;
     if (canEscape) {
       isEscaped = handleEscapeCase(feeCalculationRequest, feeEntity, validationMessages);
     }
 
-    //Step 8: build FeeCalculation
+    //Step 7: build FeeCalculation
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
         .vatIndicator(feeCalculationRequest.getVatIndicator())
@@ -74,7 +74,7 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .build();
 
-    //step 9: build response
+    //step 8: build response
     log.info("Build fee calculation response");
     return FeeCalculationResponse.builder()
         .feeCode(feeCalculationRequest.getFeeCode())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
@@ -4,7 +4,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ADVICE_ASSISTANCE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
@@ -58,7 +58,7 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
         .add(requestedWaitingCosts);
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getFeeClaimStartDate(ADVICE_ASSISTANCE_ADVOCACY, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
     BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
@@ -4,13 +4,11 @@ import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ADVICE_ASSISTANCE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,9 +56,8 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
         .add(requestedWaitingCosts);
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
     // Calculate total amount
@@ -69,7 +66,7 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
@@ -5,7 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ADVOCACY_APPE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -71,9 +71,9 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
     }
 
     // Calculate VAT if applicable
-    LocalDate startDate = getFeeClaimStartDate(ADVOCACY_APPEALS_REVIEWS, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
     // Calculate total amount

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
@@ -5,14 +5,12 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ADVOCACY_APPE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -71,9 +69,8 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
     }
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
     // Calculate total amount
@@ -82,7 +79,7 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
@@ -6,6 +6,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -73,9 +74,9 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
     }
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getStartDate();
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(feeTotal, vatRate);
 
     // Get disbursements

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
@@ -6,14 +6,12 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -74,9 +72,8 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
     }
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(feeTotal, vatRate);
 
     // Get disbursements
@@ -89,7 +86,7 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
@@ -12,6 +12,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.PROFIT_COST;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.TOTAL;
@@ -129,9 +130,9 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getStartDate();
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     // VAT is calculated on net profit costs only
     BigDecimal calculatedVatAmount = calculateVatAmount(netProfitCosts, vatRate);
 

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
@@ -12,7 +12,6 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.PROFIT_COST;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.TOTAL;
@@ -23,7 +22,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -130,9 +128,7 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
     // VAT is calculated on net profit costs only
     BigDecimal calculatedVatAmount = calculateVatAmount(netProfitCosts, vatRate);
 
@@ -176,9 +172,8 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     BigDecimal feeWithoutDisbursements = netProfitCosts.add(netCostOfCounsel);
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getStartDate();
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
     BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
@@ -234,9 +229,8 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     BigDecimal feeWithoutDisbursements = netProfitCosts.add(netCostOfCounsel).add(boltsOnTotal);
 
     // Calculate VAT if applicable
-    LocalDate startDate = feeCalculationRequest.getStartDate();
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
     BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
@@ -4,7 +4,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_POLICE_OTHER_
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -74,9 +74,9 @@ public class PoliceStationHourlyRateCalculator implements FeeCalculator {
     }
 
     // Calculate VAT if applicable
-    LocalDate claimStartDate = getFeeClaimStartDate(CategoryType.POLICE_STATION, feeCalculationRequest);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(claimStartDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(vatEligibleFeeTotal, vatRate);
 
     BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
@@ -4,14 +4,12 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_POLICE_OTHER_
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -74,9 +72,7 @@ public class PoliceStationHourlyRateCalculator implements FeeCalculator {
     }
 
     // Calculate VAT if applicable
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
     BigDecimal calculatedVatAmount = calculateVatAmount(vatEligibleFeeTotal, vatRate);
 
     BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
@@ -5,14 +5,12 @@ import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_PREORDER_C
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -71,9 +69,8 @@ public class PreOrderCoverHourlyRateCalculator implements FeeCalculator {
     }
 
     // Calculate VAT if applicable
-    Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
+    BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
+
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
     BigDecimal totalAmount = calculateTotalAmount(profitAndAdditionalCosts,
@@ -81,7 +78,7 @@ public class PreOrderCoverHourlyRateCalculator implements FeeCalculator {
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
-        .vatIndicator(vatIndicator)
+        .vatIndicator(feeCalculationRequest.getVatIndicator())
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
@@ -5,7 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_PREORDER_C
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -72,8 +72,8 @@ public class PreOrderCoverHourlyRateCalculator implements FeeCalculator {
 
     // Calculate VAT if applicable
     Boolean vatIndicator = feeCalculationRequest.getVatIndicator();
-    LocalDate startDate = getFeeClaimStartDate(PRE_ORDER_COVER, feeCalculationRequest);
-    BigDecimal vatRate = vatRatesService.getVatRateForDate(startDate, vatIndicator);
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
+    BigDecimal vatRate = vatRatesService.getVatRateForDate(caseConcludedDate, vatIndicator);
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
     BigDecimal totalAmount = calculateTotalAmount(profitAndAdditionalCosts,

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
@@ -108,6 +108,21 @@ public final class FeeCalculationUtil {
   }
 
   /**
+   * Return the case concluded date for a fee calculation request.
+   *
+   * @param feeCalculationRequest FeeCalculationRequest
+   * @return LocalDate
+   */
+  public static LocalDate getCaseConcludedDate(FeeCalculationRequest feeCalculationRequest) {
+
+    Boolean isVatRequired = feeCalculationRequest.getVatIndicator();
+    if (isVatRequired != null && isVatRequired && feeCalculationRequest.getCaseConcludedDate() == null) {
+      throw new CaseConcludedDateRequiredException(feeCalculationRequest.getFeeCode());
+    }
+    return feeCalculationRequest.getCaseConcludedDate();
+  }
+
+  /**
    * Calculate the VAT amount for a given value using the VAT rate.
    */
   public static BigDecimal calculateVatAmount(BigDecimal value, BigDecimal vatRate) {

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.fee.scheme.service;
 
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
 /**
@@ -38,5 +41,17 @@ public class VatRatesService {
 
     log.info("Retrieved VAT Rate: {}", vatRatesEntity.getVatRate());
     return vatRate;
+  }
+
+  /**
+   * Returns the VAT rate derived from the fee calculation request,
+   * resolving the case concluded date and VAT indicator from the request.
+   *
+   * @param feeCalculationRequest the fee calculation request
+   * @return the VAT rate
+   */
+  public BigDecimal getVatRateForRequest(FeeCalculationRequest feeCalculationRequest) {
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
+    return getVatRateForDate(caseConcludedDate, feeCalculationRequest.getVatIndicator());
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import java.math.BigDecimal;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +19,8 @@ public abstract class BaseFeeCalculatorTest {
   VatRatesService vatRatesService;
 
   protected void mockVatRatesService(Boolean vatIndicator) {
-    when(vatRatesService.getVatRateForDate(any(), any()))
-        .thenReturn(vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO);
+    BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
+    lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/MagistratesYouthCourtFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/MagistratesYouthCourtFeeCalculatorTest.java
@@ -45,6 +45,7 @@ class MagistratesYouthCourtFeeCalculatorTest {
         .vatIndicator(true)
         .netDisbursementAmount(50.50)
         .disbursementVatAmount(20.15)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -93,6 +94,7 @@ class MagistratesYouthCourtFeeCalculatorTest {
         .vatIndicator(true)
         .netDisbursementAmount(50.50)
         .disbursementVatAmount(20.15)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/MentalHealthFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/MentalHealthFeeCalculatorTest.java
@@ -46,6 +46,7 @@ class MentalHealthFeeCalculatorTest {
         .vatIndicator(true)
         .netDisbursementAmount(50.50)
         .disbursementVatAmount(20.15)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -93,6 +94,7 @@ class MentalHealthFeeCalculatorTest {
         .vatIndicator(true)
         .netDisbursementAmount(50.50)
         .disbursementVatAmount(20.15)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/PoliceStationFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/PoliceStationFeeCalculatorTest.java
@@ -9,6 +9,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.FeeType.FIXED;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,7 @@ class PoliceStationFeeCalculatorTest {
         .uniqueFileNumber("121222/452")
         .travelAndWaitingCosts(45.0)
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -106,6 +108,7 @@ class PoliceStationFeeCalculatorTest {
         .uniqueFileNumber("121222/452")
         .travelAndWaitingCosts(23.00)
         .netProfitCosts(450.90)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
@@ -6,6 +6,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ASSOCIATED_CI
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,6 +90,7 @@ class AssociatedCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netWaitingCosts(netWaitingCosts)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
+        .caseConcludedDate(LocalDate.of(2016, 12, 12))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/DesignatedCourtFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/DesignatedCourtFixedFeeCalculatorTest.java
@@ -67,6 +67,7 @@ class DesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .netDisbursementAmount(100.00)
           .disbursementVatAmount(20.00)
           .vatIndicator(vatIndicator)
+          .caseConcludedDate(LocalDate.of(2025, 10, 30))
           .build();
     }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EarlyCoverFixedFeeCalculatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +42,7 @@ class EarlyCoverFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .claimId("claim_123")
         .uniqueFileNumber("121222/452")
         .vatIndicator(vatIndicator)
+        .caseConcludedDate(LocalDate.of(2023, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EducationFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/EducationFixedFeeCalculatorTest.java
@@ -84,6 +84,7 @@ class EducationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netProfitCosts(netProfitCosts)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/FamilyFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/FamilyFixedFeeCalculatorTest.java
@@ -48,6 +48,7 @@ class FamilyFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -90,6 +91,7 @@ class FamilyFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netDisbursementAmount(129.45)
         .disbursementVatAmount(25.89)
         .netProfitCosts(400.00)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
@@ -64,6 +64,7 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
               .build())
           .detentionTravelAndWaitingCosts(detentionTravelAndWaitingCosts)
           .jrFormFilling(jrFormFilling)
+          .caseConcludedDate(LocalDate.of(2026, 1, 30))
           .build();
     }
 
@@ -265,6 +266,7 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
               .boltOnCmrhOral(4)
               .boltOnSubstantiveHearing(Boolean.TRUE)
               .build())
+          .caseConcludedDate(LocalDate.of(2026, 1, 30))
           .build();
     }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculatorTest.java
@@ -93,6 +93,7 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .boltOns(BoltOnType.builder().boltOnAdjournedHearing(boltOnNumber).build())
         .netProfitCosts(requestedNetProfitCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/OtherCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/OtherCivilFixedFeeCalculatorTest.java
@@ -102,6 +102,7 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netProfitCosts(501.00)
         .netDisbursementAmount(370.00)
         .disbursementVatAmount(74.00)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -134,6 +135,7 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netProfitCosts(netProfitCosts)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculatorTest.java
@@ -12,6 +12,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_POLICE_STA
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -69,6 +70,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(20.15)
         .uniqueFileNumber("121222/452")
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     when(policeStationFeesRepository.findPoliceStationFeeByPoliceStationIdAndFeeSchemeCode("NE001",
@@ -123,6 +125,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(20.15)
         .uniqueFileNumber("121222/452")
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     when(policeStationFeesRepository.findPoliceStationFeeByPsSchemeIdAndFeeSchemeCode(any(),
@@ -185,6 +188,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(20.15)
         .uniqueFileNumber(uniqueFileNumber)
         .netProfitCosts(0.00)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode(feeSchemeCode).build();
@@ -254,6 +258,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(0.00)
         .netWaitingCosts(0.00)
         .netProfitCosts(0.00)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode(feeSchemeCode).build();
@@ -294,6 +299,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netWaitingCosts(40.0)
         .netDisbursementAmount(300.0)
         .disbursementVatAmount(60.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode("POL_FS2022").build();
@@ -358,6 +364,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(35.00)
         .netWaitingCosts(10.00)
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     when(policeStationFeesRepository.findPoliceStationFeeByPoliceStationIdAndFeeSchemeCode("BLAH",
@@ -385,6 +392,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(35.00)
         .netWaitingCosts(10.00)
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     when(policeStationFeesRepository.findPoliceStationFeeByPsSchemeIdAndFeeSchemeCode("BLAH",
@@ -411,6 +419,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(35.00)
         .netWaitingCosts(10.00)
         .netProfitCosts(676.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     assertThatThrownBy(() -> policeStationFixedFeeCalculator.calculate(feeData, feeEntity))
@@ -440,6 +449,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(20.00)
         .netWaitingCosts(10.00)
         .netProfitCosts(50.00)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeCalculationResponse response = policeStationFixedFeeCalculator.calculate(feeData, feeEntity);

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PrisonLawFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PrisonLawFixedFeeCalculatorTest.java
@@ -76,6 +76,7 @@ class PrisonLawFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(disbursementVatAmount)
         .netProfitCosts(profitCosts)
         .netWaitingCosts(waitingCosts)
+        .caseConcludedDate(LocalDate.of(2018, 1, 30))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/SendingHearingFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/SendingHearingFixedFeeCalculatorTest.java
@@ -44,6 +44,7 @@ class SendingHearingFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .netDisbursementAmount(100.11)
         .disbursementVatAmount(20.22)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculatorTest.java
@@ -53,6 +53,7 @@ class StandardFixedFeeCalculatorTest {
         .vatIndicator(false)
         .netDisbursementAmount(0.0)
         .disbursementVatAmount(0.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/StandardFixedFeeCalculatorTest.java
@@ -43,7 +43,7 @@ class StandardFixedFeeCalculatorTest {
 
   @Test
   void handleEscapeCase_defaultImplementation_returnsFalse() {
-    when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(BigDecimal.ZERO);
+    when(vatRatesService.getVatRateForRequest(any())).thenReturn(BigDecimal.ZERO);
 
     TestStandardFixedFeeCalculator calculator = new TestStandardFixedFeeCalculator(vatRatesService);
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculatorTest.java
@@ -81,6 +81,7 @@ class UndesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .vatIndicator(vatIndicator)
           .netTravelCosts(requestedNetTravel)
           .netWaitingCosts(requestedNetWaiting)
+          .caseConcludedDate(LocalDate.of(2026, 1, 30))
           .build();
     }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculatorTest.java
@@ -82,6 +82,7 @@ class AdviceAssistanceAdvocacyHourlyRateCalculatorTest extends BaseFeeCalculator
         .vatIndicator(vatIndicator)
         .netTravelCosts(requestedTravelCosts)
         .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ADVOCACY_APPE
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -100,6 +101,7 @@ class AdvocacyAppealsReviewsHourlyRateCalculatorTest extends BaseFeeCalculatorTe
         .vatIndicator(vatIndicator)
         .netTravelCosts(requestedTravelCosts)
         .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
@@ -98,6 +98,7 @@ class DiscriminationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .netDisbursementAmount(65.20)
         .disbursementVatAmount(13.04)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
@@ -67,6 +67,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(disbursementVat)
         .vatIndicator(vatIndicator)
         .immigrationPriorAuthorityNumber(priorAuthority)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = buildFeeEntity(feeCode);
@@ -172,6 +173,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(disbursementVat)
         .vatIndicator(vatIndicator)
         .immigrationPriorAuthorityNumber(priorAuthority)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()
@@ -235,6 +237,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .detentionTravelAndWaitingCosts(detentionTravelAndWaitingCosts)
         .jrFormFilling(jrFormFilling)
         .vatIndicator(false)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = buildFeeEntity("IAXL");
@@ -458,6 +461,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .feeCode("IA100")
         .startDate(LocalDate.of(2025, 5, 11))
         .vatIndicator(false)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculatorTest.java
@@ -177,6 +177,7 @@ class PoliceStationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(inputNetTravelCosts)
         .netWaitingCosts(inputNetWaitingCosts)
         .uniqueFileNumber(UFN)
+        .caseConcludedDate(startDate.plusDays(15))
         .build();
 
     FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode(feeSchemeCode).build();
@@ -249,6 +250,7 @@ class PoliceStationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(inputNetTravelCosts)
         .netWaitingCosts(inputNetWaitingCosts)
         .uniqueFileNumber(UFN)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode(feeSchemeCode).build();

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculatorTest.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_PREORDER_C
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -89,6 +90,7 @@ class PreOrderCoverHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .netTravelCosts(requestedTravelCosts)
         .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
     FeeEntity feeEntity = FeeEntity.builder()

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
@@ -206,6 +206,68 @@ class FeeCalculationUtilTest {
   }
 
   @Test
+  void getCaseConcludedDate_returnsCaseConcludedDate_whenVatIndicatorIsTrue() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(Boolean.TRUE)
+        .caseConcludedDate(LocalDate.of(2022, 12, 1))
+        .build();
+
+    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
+
+    assertThat(result).isEqualTo(LocalDate.of(2022, 12, 1));
+  }
+
+  @Test
+  void getCaseConcludedDate_returnsCaseConcludedDate_whenVatIndicatorIsFalse() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(Boolean.FALSE)
+        .caseConcludedDate(LocalDate.of(2022, 12, 1))
+        .build();
+
+    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
+
+    assertThat(result).isEqualTo(LocalDate.of(2022, 12, 1));
+  }
+
+  @Test
+  void getCaseConcludedDate_returnsNull_whenVatIndicatorIsFalseAndCaseConcludedDateIsNull() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(Boolean.FALSE)
+        .caseConcludedDate(null)
+        .build();
+
+    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void getCaseConcludedDate_returnsNull_whenVatIndicatorIsNullAndCaseConcludedDateIsNull() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(null)
+        .caseConcludedDate(null)
+        .build();
+
+    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void getCaseConcludedDate_shouldThrowValidationException_whenVatIndicatorIsTrueAndCaseConcludedDateIsNull() {
+    FeeCalculationRequest request = getFeeCalculationRequest();
+    request.setCaseConcludedDate(null);
+
+    assertThatThrownBy(() -> FeeCalculationUtil.getCaseConcludedDate(request))
+        .isInstanceOf(CaseConcludedDateRequiredException.class)
+        .hasMessageContaining("Case Concluded Date is required for feeCode");
+  }
+
+  @Test
   void shouldThrowException_ifStartDateIsNull() {
     FeeCalculationRequest request = getFeeCalculationRequest();
     request.setStartDate(null);

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.fee.scheme.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
+import uk.gov.justice.laa.fee.scheme.exception.CaseConcludedDateRequiredException;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,4 +54,63 @@ class VatRatesServiceTest {
     assertThat(result).isEqualTo(BigDecimal.ZERO);
   }
 
+  @Test
+  void getVatRateForRequest_whenVatIndicatorIsTrueAndCaseConcludedDateIsSet_shouldReturnVatRate() {
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(true)
+        .caseConcludedDate(caseConcludedDate)
+        .build();
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(caseConcludedDate)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(caseConcludedDate))
+        .thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForRequest_whenVatIndicatorIsFalse_shouldReturnZero() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(false)
+        .caseConcludedDate(null)
+        .build();
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request);
+
+    assertThat(result).isEqualTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void getVatRateForRequest_whenVatIndicatorIsNull_shouldReturnZero() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(null)
+        .caseConcludedDate(null)
+        .build();
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request);
+
+    assertThat(result).isEqualTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void getVatRateForRequest_whenVatIndicatorIsTrueAndCaseConcludedDateIsNull_shouldThrowValidationException() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(true)
+        .caseConcludedDate(null)
+        .build();
+
+    assertThatThrownBy(() -> vatRatesService.getVatRateForRequest(request))
+        .isInstanceOf(CaseConcludedDateRequiredException.class)
+        .hasMessageContaining("Case Concluded Date is required for feeCode: ABC");
+  }
 }


### PR DESCRIPTION
## What
Use "Case Concluded Date" for Vat Rate retrieval from DB in crime and civil only

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-532)

Describe what you did and why.
- Added a method in FeeCalculationUtil to check vat indicator and throw an exception if case concluded date is null
- Updated all calculators (except Mediation) to retrieve vat rate using case concluded date
- Add a test case in FeeCalculationUtilTest and updated all relevant calculators test classes

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
