### PR TITLE
LFSP-418 Area of law code added in Fee Detail Response V2

### DIFF
--- a/scheme-api/open-api-specification.yml
+++ b/scheme-api/open-api-specification.yml
@@ -187,7 +187,9 @@ components:
         feeType:
           type: string
           description: "Type of fee, Fixed, Hourly, disbursement only"
-
+        areaOfLaw:
+          type: string
+          description: "Area of Law stored in the system."
     FeeDetailsResponseV1:
       required:
         - categoryOfLawCode

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -115,7 +115,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
 
-    runtimeOnly 'org.postgresql:postgresql:42.7.11'
+    runtimeOnly 'org.postgresql:postgresql:42.7.12'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-restclient'

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feedetails/FeeDetailsIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feedetails/FeeDetailsIntegrationTest.java
@@ -76,16 +76,17 @@ class FeeDetailsIntegrationTest extends PostgresContainerTestBase {
 
   private static Stream<Arguments> testCategoryOfLawCodes() {
     return Stream.of(
-        Arguments.of("CAPA", "Claims Against Public Authorities Legal Help Fixed Fee", List.of("AAP")),
-        Arguments.of("ASMS", "Legal Help and Associated Civil Work – Miscellaneous", List.of("APPEALS", "INVEST", "PRISON")),
-        Arguments.of("ASPL", "Legal Help and Associated Civil Work – Public Law", List.of("APPEALS", "INVEST", "PRISON")),
-        Arguments.of("ASAS", "Part 1 injunction Anti-Social Behaviour Crime and Policing Act 2014", List.of("APPEALS", "INVEST", "PRISON"))
+        Arguments.of("CAPA", "Claims Against Public Authorities Legal Help Fixed Fee", List.of("AAP"), "LEGAL_HELP"),
+        Arguments.of("ASMS", "Legal Help and Associated Civil Work – Miscellaneous", List.of("APPEALS", "INVEST", "PRISON"), "CRIME_LOWER"),
+        Arguments.of("ASPL", "Legal Help and Associated Civil Work – Public Law", List.of("APPEALS", "INVEST", "PRISON"), "CRIME_LOWER"),
+        Arguments.of("ASAS", "Part 1 injunction Anti-Social Behaviour Crime and Policing Act 2014", List.of("APPEALS", "INVEST", "PRISON"), "CRIME_LOWER"),
+        Arguments.of("ASSA", "Mediation Assesment (alone)", List.of("MEDI"), "MEDIATION")
     );
   }
 
   @MethodSource("testCategoryOfLawCodes")
   @ParameterizedTest
-  void shouldGetFeeDetailsV2WhenCorrelationIdProvided(String feeCode, String description, List<String> categoryOfLawCodes) throws Exception {
+  void shouldGetFeeDetailsV2WhenCorrelationIdProvided(String feeCode, String description, List<String> categoryOfLawCodes, String areaOfLawCode) throws Exception {
     String correlationId = "a51433f8-a78c-47ef-bd31-837b95467220";
     mockMvc
         .perform(get(API_V_2_FEE_DETAILS + feeCode)
@@ -93,6 +94,7 @@ class FeeDetailsIntegrationTest extends PostgresContainerTestBase {
             .header(HEADER_CORRELATION_ID, correlationId))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.areaOfLaw").value(areaOfLawCode))
         .andExpect(jsonPath("$.categoryOfLawCodes").value(is(categoryOfLawCodes)))
         .andExpect(jsonPath("$.feeCodeDescription").value(description))
         .andExpect(jsonPath("$.feeType").value("FIXED"))
@@ -101,12 +103,13 @@ class FeeDetailsIntegrationTest extends PostgresContainerTestBase {
 
   @MethodSource("testCategoryOfLawCodes")
   @ParameterizedTest
-  void shouldGetFeeDetailsV2WhenCorrelationIdNotProvided(String feeCode, String description, List<String> categoryOfLawCodes) throws Exception {
+  void shouldGetFeeDetailsV2WhenCorrelationIdNotProvided(String feeCode, String description, List<String> categoryOfLawCodes, String areaOfLawCode) throws Exception {
     mockMvc
         .perform(get(API_V_2_FEE_DETAILS + feeCode)
             .header(HttpHeaders.AUTHORIZATION, INT_TEST_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.areaOfLaw").value(areaOfLawCode))
         .andExpect(jsonPath("$.categoryOfLawCodes").value(is(categoryOfLawCodes)))
         .andExpect(jsonPath("$.feeCodeDescription").value(description))
         .andExpect(jsonPath("$.feeType").value("FIXED"))

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/FeeDetailsService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/FeeDetailsService.java
@@ -71,6 +71,7 @@ public class FeeDetailsService {
         .categoryOfLawCodes(categoryOfLawCodes)
         .feeCodeDescription(feeCategoryMapping.getFeeCode().getFeeDescription())
         .feeType(feeCategoryMapping.getFeeCode().getFeeType().toString())
+        .areaOfLaw(feeCategoryMapping.getCategoryOfLawType().getAreaOfLawType().getCode().toString())
         .build();
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/FeeDetailsServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/FeeDetailsServiceTest.java
@@ -78,7 +78,14 @@ class FeeDetailsServiceTest {
   void getFeeDetailsV2_shouldReturnExpectedFeeDetails() {
     String feeCode = "FEE123";
 
-    CategoryOfLawTypeEntity categoryOfLawType = CategoryOfLawTypeEntity.builder().code("AAP").build();
+    AreaOfLawTypeEntity areaOfLawType = AreaOfLawTypeEntity.builder()
+        .code(AreaOfLawType.LEGAL_HELP)
+        .caseType(CaseType.CIVIL)
+        .build();
+    CategoryOfLawTypeEntity categoryOfLawType = CategoryOfLawTypeEntity.builder()
+        .code("AAP")
+        .areaOfLawType(areaOfLawType)
+        .build();
 
     // Mock FeeInformationEntity
     FeeInformationEntity feeInformation = mock(FeeInformationEntity.class);
@@ -96,6 +103,7 @@ class FeeDetailsServiceTest {
     assertThat(response.getCategoryOfLawCodes()).isEqualTo(List.of("AAP"));
     assertThat(response.getFeeCodeDescription()).isEqualTo("Claims Against Public Authorities Legal Help Fixed Fee");
     assertThat(response.getFeeType()).isEqualTo("FIXED");
+    assertThat(response.getAreaOfLaw()).isEqualTo("LEGAL_HELP");
   }
 
   @CsvSource({
@@ -106,12 +114,22 @@ class FeeDetailsServiceTest {
   @ParameterizedTest
   void getFeeDetailsV2_whenGivenAssociatedCivilFeeCode_shouldReturnExpectedFeeDetails(String feeCode, String description) {
 
+    AreaOfLawTypeEntity areaOfLawType = AreaOfLawTypeEntity.builder()
+        .code(AreaOfLawType.LEGAL_HELP)
+        .caseType(CaseType.CIVIL)
+        .build();
+    CategoryOfLawTypeEntity categoryOfLawType = CategoryOfLawTypeEntity.builder()
+        .code("AAP")
+        .areaOfLawType(areaOfLawType)
+        .build();
+
     // Mock FeeInformationEntity
     FeeInformationEntity feeInformation = mock(FeeInformationEntity.class);
     when(feeInformation.getFeeDescription()).thenReturn(description);
     when(feeInformation.getFeeType()).thenReturn(FeeType.FIXED);
 
     FeeCategoryMappingEntity feeCategoryMappingEntity = mock(FeeCategoryMappingEntity.class);
+    when(feeCategoryMappingEntity.getCategoryOfLawType()).thenReturn(categoryOfLawType);
     when(feeCategoryMappingEntity.getFeeCode()).thenReturn(feeInformation); // return mock
 
     when(feeCategoryMappingRepository.findByFeeCodeFeeCode(any())).thenReturn(Optional.of(feeCategoryMappingEntity));
@@ -121,6 +139,7 @@ class FeeDetailsServiceTest {
     assertThat(response.getCategoryOfLawCodes()).isEqualTo(List.of("APPEALS", "INVEST", "PRISON"));
     assertThat(response.getFeeCodeDescription()).isEqualTo(description);
     assertThat(response.getFeeType()).isEqualTo("FIXED");
+    assertThat(response.getAreaOfLaw()).isEqualTo("LEGAL_HELP");
   }
 
   @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-418)

Updated open spec yml file to add areaoflaw code in Fee Detail Response V2 and in service layer, this field is mapped with value returning from database. 

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
