### PR TITLE
LFSP-424: cap disbursement VAT on Immigration & Asylum fixed fee calculations

### DIFF
--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
@@ -173,20 +173,20 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
   @ParameterizedTest
   @CsvSource(value = {
       // feeCode, startDate, feeScheme, total, vat, fixedFee, boltOn, boltOnFee
-      "IACA, 2022-09-30, IMM_ASYLM_FS2020, 785.13, 110.8, 227.0, CmrhOral, 166.0",
-      "IACB, 2022-09-30, IMM_ASYLM_FS2020, 1555.53, 239.2, 869.0, CmrhOral, 166.0",
-      "IACC, 2022-09-30, IMM_ASYLM_FS2020, 1627.53, 251.2, 929.0, CmrhOral, 166.0",
-      "IACE, 2025-12-22, IMM_ASYLM_FS2025, 1502.73, 230.4, 808.0, CmrhOral, 183.0", // uplift 2025
-      "IACF, 2025-12-22, IMM_ASYLM_FS2025, 2394.33, 379.0, 1551.0, CmrhOral, 183.0", // uplift 2025
-      "IALB, 2025-12-22, IMM_ASYLM_FS2025, 1416.33, 216.0, 559.0, HomeOfficeInterview, 360", // uplift 2025
-      "IMCA, 2022-09-30, IMM_ASYLM_FS2020, 785.13, 110.8, 227.0, CmrhOral, 166.0",
-      "IMCB, 2022-09-30, IMM_ASYLM_FS2020, 1341.93, 203.6, 691.0, CmrhOral, 166.0",
-      "IMCC, 2022-09-30, IMM_ASYLM_FS2020, 1429.53, 218.2, 764.0, CmrhOral, 166.0",
-      "IMCE, 2025-12-22, IMM_ASYLM_FS2025,  1443.93, 220.6, 759.0, CmrhOral, 183.0", // uplift 2025
-      "IMCF, 2025-12-22, IMM_ASYLM_FS2025, 2085.93, 327.6, 1294.0, CmrhOral, 183.0", // uplift 2025
-      "IMLB, 2025-12-22, IMM_ASYLM_FS2025, 1125.93, 167.6, 317.0, HomeOfficeInterview, 360", // uplift 2025
-      "IDAS1, 2025-12-22, IMM_ASYLM_FS2025, 612.33, 82.0, 249.0, null, 0", // uplift 2025
-      "IDAS2, 2025-12-22, IMM_ASYLM_FS2025, 909.93, 131.6, 497.0, null, 0" // uplift 2025
+      "IACA, 2022-09-30, IMM_ASYLM_FS2020, 785.05, 110.8, 227.0, CmrhOral, 166.0",
+      "IACB, 2022-09-30, IMM_ASYLM_FS2020, 1555.45, 239.2, 869.0, CmrhOral, 166.0",
+      "IACC, 2022-09-30, IMM_ASYLM_FS2020, 1627.45, 251.2, 929.0, CmrhOral, 166.0",
+      "IACE, 2025-12-22, IMM_ASYLM_FS2025, 1502.65, 230.4, 808.0, CmrhOral, 183.0", // uplift 2025
+      "IACF, 2025-12-22, IMM_ASYLM_FS2025, 2394.25, 379.0, 1551.0, CmrhOral, 183.0", // uplift 2025
+      "IALB, 2025-12-22, IMM_ASYLM_FS2025, 1416.25, 216.0, 559.0, HomeOfficeInterview, 360", // uplift 2025
+      "IMCA, 2022-09-30, IMM_ASYLM_FS2020, 785.05, 110.8, 227.0, CmrhOral, 166.0",
+      "IMCB, 2022-09-30, IMM_ASYLM_FS2020, 1341.85, 203.6, 691.0, CmrhOral, 166.0",
+      "IMCC, 2022-09-30, IMM_ASYLM_FS2020, 1429.45, 218.2, 764.0, CmrhOral, 166.0",
+      "IMCE, 2025-12-22, IMM_ASYLM_FS2025,  1443.85, 220.6, 759.0, CmrhOral, 183.0", // uplift 2025
+      "IMCF, 2025-12-22, IMM_ASYLM_FS2025, 2085.85, 327.6, 1294.0, CmrhOral, 183.0", // uplift 2025
+      "IMLB, 2025-12-22, IMM_ASYLM_FS2025, 1125.85, 167.6, 317.0, HomeOfficeInterview, 360", // uplift 2025
+      "IDAS1, 2025-12-22, IMM_ASYLM_FS2025, 612.25, 82.0, 249.0, null, 0", // uplift 2025
+      "IDAS2, 2025-12-22, IMM_ASYLM_FS2025, 909.85, 131.6, 497.0, null, 0" // uplift 2025
   }, nullValues = {"null"})
   void shouldGetImmigrationAndAsylumFixedFeeCalculation(String feeCode, LocalDate startDate, String feeScheme,
                                                             double total, double vat, double fixedFee,
@@ -204,8 +204,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
             "calculatedVatAmount": %s,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.00,
             "jrFormFillingAmount": 50
@@ -226,8 +226,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
             "calculatedVatAmount": %s,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.00,
             "jrFormFillingAmount": 50,
@@ -246,7 +246,7 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "startDate": "%s",
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
           "jrFormFilling": 50.00,
@@ -255,6 +255,58 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
     request = (boltOn != null) ? request + ", \"boltOns\": { \"boltOn%s\": 1 }}".formatted(boltOn) : request + "}";
 
     postAndExpect(request, boltOn != null ? expectedJsonWithBoltOns : expectedJson);
+  }
+
+  @Test
+  void shouldCapImmigrationAndAsylumFixedFeeDisbursementVatWhenExceedsMaximum() throws Exception {
+    String request = """
+        {
+          "feeCode": "IACA",
+          "claimId": "claim_123",
+          "startDate": "2022-09-30",
+          "netDisbursementAmount": 100.21,
+          "disbursementVatAmount": 50.00,
+          "vatIndicator": true,
+          "detentionTravelAndWaitingCosts": 111.00,
+          "jrFormFilling": 50.00,
+          "boltOns": { "boltOnCmrhOral": 1 },
+          "caseConcludedDate": "2026-02-01"
+        }
+        """;
+
+    postAndExpect(request, """
+        {
+          "feeCode": "IACA",
+          "schemeId": "IMM_ASYLM_FS2020",
+          "claimId": "claim_123",
+          "validationMessages": [
+            {
+              "type": "WARNING",
+              "code": "WARALL1",
+              "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable."
+            }
+          ],
+          "escapeCaseFlag": false,
+          "feeCalculation": {
+            "totalAmount": 785.05,
+            "vatIndicator": true,
+            "vatRateApplied": 20.00,
+            "calculatedVatAmount": 110.8,
+            "disbursementAmount": 100.21,
+            "requestedNetDisbursementAmount": 100.21,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 50.00,
+            "fixedFeeAmount": 227.0,
+            "detentionTravelAndWaitingCostsAmount": 111.00,
+            "jrFormFillingAmount": 50,
+            "boltOnFeeDetails": {
+              "boltOnTotalFeeAmount": 166.0,
+              "boltOnCmrhOralCount": 1,
+              "boltOnCmrhOralFee": 166.0
+            }
+          }
+        }
+        """);
   }
 
   @Test

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
@@ -761,11 +761,11 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
   @ParameterizedTest
   @CsvSource({
     "IMCF, WARIA1, Costs have been capped at £600 without an Immigration Priority Authority Number. "
-        + "Disbursement costs exceed the Disbursement Limit., false, 2173.72, 250.6, 650.0, 600.0, 1092.0, 0",
+        + "Disbursement costs exceed the Disbursement Limit., false, 2113.60, 250.6, 650.0, 600.0, 1092.0, 0",
     "IALB, WARIA2, Costs have been capped at £400 without an Immigration Priority Authority Number. "
-        + "Disbursement costs exceed the Disbursement Limit., false, 1158.92, 114.8, 450.0, 400.0, 413.0, 0",
+        + "Disbursement costs exceed the Disbursement Limit., false, 1098.80, 114.8, 450.0, 400.0, 413.0, 0",
     "IACE, WARIA3, The claim exceeds the Escape Case Threshold. "
-        + "An Escape Case Claim must be submitted for further costs to be paid., true, 1116.12, 166.0, 50.0, 50.0, 669.0, 1500"
+        + "An Escape Case Claim must be submitted for further costs to be paid., true, 1056.00, 166.0, 50.0, 50.0, 669.0, 1500"
   })
   void shouldReturnValidationWarningForImmigrationAndAsylumFixedFee(
       String feeCode,
@@ -786,7 +786,7 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "claimId": "claim_123",
           "startDate": "2024-09-30",
           "netDisbursementAmount": %s,
-          "disbursementVatAmount": 70.12,
+          "disbursementVatAmount": 10.00,
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
           "jrFormFilling": 50.00,
@@ -818,8 +818,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
             "calculatedVatAmount": %s,
             "requestedNetDisbursementAmount": %s,
             "disbursementAmount": %s,
-            "disbursementVatAmount": 70.12,
-            "requestedDisbursementVatAmount": 70.12,
+            "disbursementVatAmount": 10.00,
+            "requestedDisbursementVatAmount": 10.00,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.0,
             "jrFormFillingAmount": 50.0

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
@@ -118,6 +118,18 @@ public class GlobalExceptionHandler {
   }
 
   /**
+   * Global exception handler for VatRateNotFoundException exception.
+   * No VAT rate exists for the date derived from the request.
+   *
+   * @param ex the exception thrown when no VAT rate is found for the given date.
+   * @return the error response and a 404 Not Found status code.
+   */
+  @ExceptionHandler(VatRateNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleVatRateNotFound(VatRateNotFoundException ex) {
+    return handleException("VAT rate not found error", ex, HttpStatus.NOT_FOUND);
+  }
+
+  /**
    * Global exception handler for StartDateRequiredException exception.
    * Start date is required for fee calculation but was not provided in the request.
    *

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/VatRateNotFoundException.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/VatRateNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.justice.laa.fee.scheme.exception;
+
+import java.time.LocalDate;
+
+/**
+ * Exception when no VAT rate is found for the supplied date.
+ */
+public class VatRateNotFoundException extends RuntimeException {
+  public VatRateNotFoundException(LocalDate date) {
+    super(String.format("No VAT rate found for date: %s", date));
+  }
+}

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
@@ -7,7 +7,9 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_ESC
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
@@ -70,8 +72,6 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
     log.info("Get fields from fee calculation request");
     // get the requested disbursement amount from feeCalculationRequest
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    // get the requested disbursement VAT amount from feeCalculationRequest
-    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
     // get the requested detentionTravelAndWaitingCosts amount from feeCalculationRequest
     BigDecimal requestedDetentionTravelAndWaitingCosts = toBigDecimal(feeCalculationRequest.getDetentionTravelAndWaitingCosts());
     // get the requested jrFormFilling amount from feeCalculationRequest
@@ -110,9 +110,13 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
 
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
+    // cap the disbursement VAT at the applicable rate of the (capped) net disbursement
+    BigDecimal disbursementVatAmount =
+        capDisbursementVatForRequest(feeCalculationRequest, netDisbursementAmount, validationMessages);
+
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAndAdditionalCosts,
-        calculatedVatAmount, netDisbursementAmount, requestedDisbursementVatAmount);
+        calculatedVatAmount, netDisbursementAmount, disbursementVatAmount);
 
     boolean escapeCaseFlag = false;
     if (!FEE_CODES_NO_DISBURSEMENT_LIMIT_AND_NO_ESCAPE.contains(feeCalculationRequest.getFeeCode())) {
@@ -127,7 +131,7 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(netDisbursementAmount) : null)
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(nonNull(feeCalculationRequest.getDisbursementVatAmount()) ? toDouble(disbursementVatAmount) : null)
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .detentionTravelAndWaitingCostsAmount(feeCalculationRequest.getDetentionTravelAndWaitingCosts())
@@ -136,6 +140,20 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .build();
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages, escapeCaseFlag);
+  }
+
+  /**
+   * Cap the disbursement VAT at the VAT rate (looked up by case concluded date) applied to the net disbursement.
+   */
+  private BigDecimal capDisbursementVatForRequest(FeeCalculationRequest feeCalculationRequest,
+      BigDecimal netDisbursementAmount, List<ValidationMessagesInner> validationMessages) {
+    BigDecimal requestedDisbursementVat = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    if (BigDecimal.ZERO.compareTo(requestedDisbursementVat) == 0) {
+      return BigDecimal.ZERO;
+    }
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest));
+    return capDisbursementVat(netDisbursementAmount, requestedDisbursementVat,
+        disbursementVatRate, validationMessages);
   }
 
   /**

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
@@ -4,11 +4,13 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
+import uk.gov.justice.laa.fee.scheme.exception.VatRateNotFoundException;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
@@ -46,7 +48,9 @@ public class VatRatesService {
    * @return the VAT rate
    */
   public BigDecimal getVatRateForDate(LocalDate date) {
-    VatRatesEntity vatRatesEntity = vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date);
+    VatRatesEntity vatRatesEntity =
+        Optional.ofNullable(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date))
+            .orElseThrow(() -> new VatRateNotFoundException(date));
 
     log.info("Retrieved VAT Rate: {}", vatRatesEntity.getVatRate());
     return vatRatesEntity.getVatRate();

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -24,7 +24,7 @@ public abstract class BaseFeeCalculatorTest {
   protected void mockVatRatesService(Boolean vatIndicator) {
     BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
     lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
-    lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForDate(any())).thenReturn(new BigDecimal("20.00"));
     lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
     lenient().when(vatRatesService.getVatRateForRequest(any(), any())).thenReturn(new BigDecimal("20.00"));
   }
@@ -32,10 +32,5 @@ public abstract class BaseFeeCalculatorTest {
   protected void mockVatRatesVatIndicatorTrue() {
     when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
         .thenReturn(new BigDecimal("20.00"));
-  }
-
-  protected void mockVatRatesVatIndicatorTrue() {
-    when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
-            .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.IMMIGRATION_ASYLUM;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.FIXED;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_400_LEGAL_HELP;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_600_CLR;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_ESCAPE_THRESHOLD;
@@ -245,6 +246,32 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
       assertThat(response.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "IACA, 100.0, 50.0, 600.0, 20.0, 50.0",
+        "IALB, 1000.0, 200.0, 400.0, 80.0, 200.0"
+    })
+    void calculate_capsDisbursementVatAtRateOfCappedNetDisbursement(String feeCode, double netDisbursementAmount,
+        double disbursementVatAmount, double disbursementLimit, double expectedDisbursementVat,
+        double expectedRequestedDisbursementVat) {
+
+      mockVatRatesService(true);
+
+      FeeCalculationRequest feeData = buildRequest(feeCode, netDisbursementAmount, disbursementVatAmount, true,
+          null, 0.0, 0.0);
+
+      FeeEntity feeEntity = buildFeeEntity(feeCode, BigDecimal.valueOf(75.5), BigDecimal.valueOf(disbursementLimit),
+          BigDecimal.valueOf(166), BigDecimal.valueOf(90), BigDecimal.valueOf(302));
+
+      FeeCalculationResponse response = immigrationAsylumFixedFeeCalculator.calculate(feeData, feeEntity);
+
+      assertThat(response.getFeeCalculation().getDisbursementVatAmount()).isEqualTo(expectedDisbursementVat);
+      assertThat(response.getFeeCalculation().getRequestedDisbursementVatAmount()).isEqualTo(expectedRequestedDisbursementVat);
+      assertThat(response.getValidationMessages())
+          .extracting(ValidationMessagesInner::getCode)
+          .contains(WARN_DISBURSEMENT_VAT_CAPPED.getCode());
+    }
+
   }
 
   @Nested
@@ -257,7 +284,6 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .claimId("claim_123")
           .startDate(LocalDate.of(2025, 7, 29))
           .netDisbursementAmount(netDisbursementAmount)
-          .disbursementVatAmount(20.0)
           .vatIndicator(true)
           .immigrationPriorAuthorityNumber(null)
           .netProfitCosts(requestedNetProfitCosts)

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -43,6 +43,21 @@ class VatRatesServiceTest {
     assertThat(result).isEqualTo(new BigDecimal("20.00"));
   }
 
+  @Test
+  void getVatRateForDate_shouldReturnVatRateRegardlessOfVatIndicator() {
+    LocalDate date = LocalDate.of(2025, 3, 15);
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(date)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForDate(date);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
   @NullSource
   @ValueSource(booleans = {false})
   @ParameterizedTest

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
 import uk.gov.justice.laa.fee.scheme.exception.CaseConcludedDateRequiredException;
+import uk.gov.justice.laa.fee.scheme.exception.VatRateNotFoundException;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
@@ -145,6 +146,16 @@ class VatRatesServiceTest {
     BigDecimal result = vatRatesService.getVatRateForDate(date);
 
     assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForDate_whenNoVatRateForDate_shouldThrowVatRateNotFound() {
+    LocalDate date = LocalDate.of(1980, 1, 1);
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(null);
+
+    assertThatThrownBy(() -> vatRatesService.getVatRateForDate(date))
+        .isInstanceOf(VatRateNotFoundException.class)
+        .hasMessageContaining("No VAT rate found for date: 1980-01-01");
   }
 
   @Test


### PR DESCRIPTION
Caps disbursement VAT on I&A fixed-fee claims so a provider can't over-claim VAT on disbursements. After the existing net-disbursement cap, the calculator looks up the VAT rate by case concluded date and caps the entered disbursement VAT at the rate applied to the (capped) net disbursement. If the entered value exceeds the maximum it's capped and a `WARALL1` warning is returned. Uses the capped net for the ceiling, per the ticket's I&A nuance.

## Changes
- `ImmigrationAsylumFixedFeeCalculator`: cap disbursement VAT (via a `capDisbursementVatForRequest` helper), rate looked up by case concluded date.
- Shared cap machinery: `WARALL1` warning, `DISBURSEMENT_VAT` limit type, `FeeCalculationUtil.capDisbursementVat`, un-gated `VatRatesService.getVatRateForDate(date)`.
- Tests: unit (basic cap + capped-net nuance), a dedicated integration cap test, a direct `getVatRateForDate(date)` test, plus updates to existing I&A fixed-fee/validation rows whose data slightly over-claimed.

# Not capped
<img width="1292" height="991" alt="Screenshot 2026-07-10 at 09 58 50" src="https://github.com/user-attachments/assets/460131a5-1340-4ada-91ff-3be7817ea223" />

# Capped
<img width="1306" height="986" alt="Screenshot 2026-07-10 at 09 59 16" src="https://github.com/user-attachments/assets/97ac3b94-afe0-4ac9-a9e7-21a57a38740f" />

# WARIA1 Capped
<img width="1316" height="1008" alt="Screenshot 2026-07-10 at 09 59 37" src="https://github.com/user-attachments/assets/7c64636b-ebb9-4c85-8ff1-0fe51a62b039" />

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.