### PR TITLE
Release/disbursement vat changes [DO NOT MERGE]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,24 +6,32 @@ ignore:
     - '*':
         reason: no fix available, not exploitable
         expires: 2099-01-01T00:00:00.000Z
+  SNYK-JAVA-TOOLSJACKSONCORE-17972609:
+      - '*':
+        reason: no fix available; not exploitable - app does not use annotations @JsonView and @JsonUnwrapped (LFSP-549)
+        expires: 2099-01-01T00:00:00.000Z
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-17972608:
+      - '*':
+        reason: no fix available; not exploitable - app does not use annotations @JsonView and @JsonUnwrapped (LFSP-549)
+        expires: 2099-01-01T00:00:00.000Z
   SNYK-JAVA-ORGAPACHETOMCATEMBED-16691231:
     - '*':
-        reason: no fix available, not exploitable
-        expires: 2099-01-01T00:00:00.000Z
+       reason: no fix available, not exploitable
+       expires: 2099-01-01T00:00:00.000Z
   SNYK-JAVA-ORGAPACHETOMCATEMBED-16643259:
       - '*':
-          reason: no fix available, not exploitable
-          expires: 2099-01-01T00:00:00.000Z
+        reason: no fix available, not exploitable
+        expires: 2099-01-01T00:00:00.000Z
   SNYK-JAVA-ORGAPACHETOMCATEMBED-17732890:
       - '*':
-          reason: no fix available, not exploitable
-          expires: 2099-01-01T00:00:00.000Z
+        reason: no fix available, not exploitable
+        expires: 2099-01-01T00:00:00.000Z
   SNYK-JAVA-ORGAPACHETOMCATEMBED-17733746:
       - '*':
-          reason: no fix available, not exploitable
-          expires: 2099-01-01T00:00:00.000Z
+        reason: no fix available, not exploitable
+        expires: 2099-01-01T00:00:00.000Z
   SNYK-JAVA-CHQOSLOGBACK-17675439:
       - '*':
-          reason: no fix available, not exploitable
-          expires: 2099-01-01T00:00:00.000Z
+        reason: no fix available, not exploitable
+        expires: 2099-01-01T00:00:00.000Z
 patch: {}

--- a/scheme-api/build.gradle
+++ b/scheme-api/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
     implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.22.0'
-    implementation 'tools.jackson.core:jackson-core:3.2.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.22.1'
+    implementation 'tools.jackson.core:jackson-core:3.2.1'
 }
 
 sourceSets.main.java.srcDirs += ['generated/src/main/java']

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'io.freefair.lombok' version '9.5.0'
     id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
-    id "io.sentry.jvm.gradle" version "6.13.0"
+    id "io.sentry.jvm.gradle" version "6.14.0"
     id 'info.solidsoft.pitest'
 }
 
 def versions = [
-        sentry 						: '8.46.0'
+        sentry 						: '8.48.0'
 ]
 
 test {
@@ -108,14 +108,14 @@ dependencies {
 
     implementation 'uk.gov.laa.springboot:laa-spring-boot-starter-auth'
 
-    implementation 'org.flywaydb:flyway-core:12.9.0'
-    implementation 'org.flywaydb:flyway-database-postgresql:12.9.0'
+    implementation 'org.flywaydb:flyway-core:12.11.0'
+    implementation 'org.flywaydb:flyway-database-postgresql:12.11.0'
 
     implementation 'io.micrometer:micrometer-registry-prometheus:1.17.0'
 
     implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
 
-    runtimeOnly 'org.postgresql:postgresql:42.7.12'
+    runtimeOnly 'org.postgresql:postgresql:42.7.13'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-restclient'

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationDisbursementOnlyIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationDisbursementOnlyIntegrationTest.java
@@ -10,7 +10,7 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
 
   @Test
   void shouldReturnFeeCalculationForEducationDisbursementOnly() throws Exception {
-    String request = """ 
+    String request = """
         {
           "feeCode": "EDUDIS",
           "claimId": "claim_123",
@@ -40,7 +40,7 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
 
   @Test
   void shouldReturnFeeCalculationForImmigrationDisbursementOnly() throws Exception {
-    String request = """ 
+    String request = """
         {
           "feeCode": "ICASD",
           "claimId": "claim_123",
@@ -64,14 +64,13 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
             "requestedDisbursementVatAmount": 11.07
             }
           }
-        }
         """);
     assertThat(actualResponse).isNotBlank();
   }
 
   @Test
   void shouldReturnFeeCalculationForMentalHealthDisbursementOnly() throws Exception {
-    String request = """ 
+    String request = """
         {
           "feeCode": "MHLDIS",
           "claimId": "claim_123",
@@ -95,6 +94,42 @@ class FeeCalculationDisbursementOnlyIntegrationTest extends BaseFeeCalculationIn
             "requestedDisbursementVatAmount": 150.0
             }
           }
+        """);
+    assertThat(actualResponse).isNotBlank();
+  }
+
+  @Test
+  void shouldCapDisbursementVatAndWarnWhenVatExceedsMaximum() throws Exception {
+    String request = """
+        {
+          "feeCode": "ICASD",
+          "claimId": "claim_123",
+          "startDate": "2013-04-01",
+          "netDisbursementAmount": 100.00,
+          "disbursementVatAmount": 50.00,
+          "caseConcludedDate": "2026-02-01"
+        }
+        """;
+
+    String actualResponse = postAndExpect(request, """
+        {
+          "feeCode": "ICASD",
+          "schemeId": "IMM_ASYLM_DISBURSEMENT_FS2013",
+          "claimId": "claim_123",
+          "validationMessages": [
+            {
+              "type": "WARNING",
+              "code": "WARALL1",
+              "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable."
+            }
+          ],
+          "feeCalculation": {
+            "totalAmount": 120.00,
+            "disbursementAmount": 100.00,
+            "requestedNetDisbursementAmount": 100.00,
+            "disbursementVatAmount": 20.00,
+            "requestedDisbursementVatAmount": 50.00
+           }
         }
         """);
     assertThat(actualResponse).isNotBlank();

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
@@ -173,20 +173,20 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
   @ParameterizedTest
   @CsvSource(value = {
       // feeCode, startDate, feeScheme, total, vat, fixedFee, boltOn, boltOnFee
-      "IACA, 2022-09-30, IMM_ASYLM_FS2020, 785.13, 110.8, 227.0, CmrhOral, 166.0",
-      "IACB, 2022-09-30, IMM_ASYLM_FS2020, 1555.53, 239.2, 869.0, CmrhOral, 166.0",
-      "IACC, 2022-09-30, IMM_ASYLM_FS2020, 1627.53, 251.2, 929.0, CmrhOral, 166.0",
-      "IACE, 2025-12-22, IMM_ASYLM_FS2025, 1502.73, 230.4, 808.0, CmrhOral, 183.0", // uplift 2025
-      "IACF, 2025-12-22, IMM_ASYLM_FS2025, 2394.33, 379.0, 1551.0, CmrhOral, 183.0", // uplift 2025
-      "IALB, 2025-12-22, IMM_ASYLM_FS2025, 1416.33, 216.0, 559.0, HomeOfficeInterview, 360", // uplift 2025
-      "IMCA, 2022-09-30, IMM_ASYLM_FS2020, 785.13, 110.8, 227.0, CmrhOral, 166.0",
-      "IMCB, 2022-09-30, IMM_ASYLM_FS2020, 1341.93, 203.6, 691.0, CmrhOral, 166.0",
-      "IMCC, 2022-09-30, IMM_ASYLM_FS2020, 1429.53, 218.2, 764.0, CmrhOral, 166.0",
-      "IMCE, 2025-12-22, IMM_ASYLM_FS2025,  1443.93, 220.6, 759.0, CmrhOral, 183.0", // uplift 2025
-      "IMCF, 2025-12-22, IMM_ASYLM_FS2025, 2085.93, 327.6, 1294.0, CmrhOral, 183.0", // uplift 2025
-      "IMLB, 2025-12-22, IMM_ASYLM_FS2025, 1125.93, 167.6, 317.0, HomeOfficeInterview, 360", // uplift 2025
-      "IDAS1, 2025-12-22, IMM_ASYLM_FS2025, 612.33, 82.0, 249.0, null, 0", // uplift 2025
-      "IDAS2, 2025-12-22, IMM_ASYLM_FS2025, 909.93, 131.6, 497.0, null, 0" // uplift 2025
+      "IACA, 2022-09-30, IMM_ASYLM_FS2020, 785.05, 110.8, 227.0, CmrhOral, 166.0",
+      "IACB, 2022-09-30, IMM_ASYLM_FS2020, 1555.45, 239.2, 869.0, CmrhOral, 166.0",
+      "IACC, 2022-09-30, IMM_ASYLM_FS2020, 1627.45, 251.2, 929.0, CmrhOral, 166.0",
+      "IACE, 2025-12-22, IMM_ASYLM_FS2025, 1502.65, 230.4, 808.0, CmrhOral, 183.0", // uplift 2025
+      "IACF, 2025-12-22, IMM_ASYLM_FS2025, 2394.25, 379.0, 1551.0, CmrhOral, 183.0", // uplift 2025
+      "IALB, 2025-12-22, IMM_ASYLM_FS2025, 1416.25, 216.0, 559.0, HomeOfficeInterview, 360", // uplift 2025
+      "IMCA, 2022-09-30, IMM_ASYLM_FS2020, 785.05, 110.8, 227.0, CmrhOral, 166.0",
+      "IMCB, 2022-09-30, IMM_ASYLM_FS2020, 1341.85, 203.6, 691.0, CmrhOral, 166.0",
+      "IMCC, 2022-09-30, IMM_ASYLM_FS2020, 1429.45, 218.2, 764.0, CmrhOral, 166.0",
+      "IMCE, 2025-12-22, IMM_ASYLM_FS2025,  1443.85, 220.6, 759.0, CmrhOral, 183.0", // uplift 2025
+      "IMCF, 2025-12-22, IMM_ASYLM_FS2025, 2085.85, 327.6, 1294.0, CmrhOral, 183.0", // uplift 2025
+      "IMLB, 2025-12-22, IMM_ASYLM_FS2025, 1125.85, 167.6, 317.0, HomeOfficeInterview, 360", // uplift 2025
+      "IDAS1, 2025-12-22, IMM_ASYLM_FS2025, 612.25, 82.0, 249.0, null, 0", // uplift 2025
+      "IDAS2, 2025-12-22, IMM_ASYLM_FS2025, 909.85, 131.6, 497.0, null, 0" // uplift 2025
   }, nullValues = {"null"})
   void shouldGetImmigrationAndAsylumFixedFeeCalculation(String feeCode, LocalDate startDate, String feeScheme,
                                                             double total, double vat, double fixedFee,
@@ -204,8 +204,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
             "calculatedVatAmount": %s,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.00,
             "jrFormFillingAmount": 50
@@ -226,8 +226,8 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
             "calculatedVatAmount": %s,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.00,
             "jrFormFillingAmount": 50,
@@ -246,7 +246,7 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "startDate": "%s",
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
           "jrFormFilling": 50.00,
@@ -255,6 +255,58 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
     request = (boltOn != null) ? request + ", \"boltOns\": { \"boltOn%s\": 1 }}".formatted(boltOn) : request + "}";
 
     postAndExpect(request, boltOn != null ? expectedJsonWithBoltOns : expectedJson);
+  }
+
+  @Test
+  void shouldCapImmigrationAndAsylumFixedFeeDisbursementVatWhenExceedsMaximum() throws Exception {
+    String request = """
+        {
+          "feeCode": "IACA",
+          "claimId": "claim_123",
+          "startDate": "2022-09-30",
+          "netDisbursementAmount": 100.21,
+          "disbursementVatAmount": 50.00,
+          "vatIndicator": true,
+          "detentionTravelAndWaitingCosts": 111.00,
+          "jrFormFilling": 50.00,
+          "boltOns": { "boltOnCmrhOral": 1 },
+          "caseConcludedDate": "2026-02-01"
+        }
+        """;
+
+    postAndExpect(request, """
+        {
+          "feeCode": "IACA",
+          "schemeId": "IMM_ASYLM_FS2020",
+          "claimId": "claim_123",
+          "validationMessages": [
+            {
+              "type": "WARNING",
+              "code": "WARALL1",
+              "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable."
+            }
+          ],
+          "escapeCaseFlag": false,
+          "feeCalculation": {
+            "totalAmount": 785.05,
+            "vatIndicator": true,
+            "vatRateApplied": 20.00,
+            "calculatedVatAmount": 110.8,
+            "disbursementAmount": 100.21,
+            "requestedNetDisbursementAmount": 100.21,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 50.00,
+            "fixedFeeAmount": 227.0,
+            "detentionTravelAndWaitingCostsAmount": 111.00,
+            "jrFormFillingAmount": 50,
+            "boltOnFeeDetails": {
+              "boltOnTotalFeeAmount": 166.0,
+              "boltOnCmrhOralCount": 1,
+              "boltOnCmrhOralFee": 166.0
+            }
+          }
+        }
+        """);
   }
 
   @Test

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationFixedFeeIntegrationTest.java
@@ -265,7 +265,7 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "startDate": "2019-09-30",
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "numberOfMediationSessions": 1,
           "caseConcludedDate": "2026-02-01"
@@ -278,14 +278,14 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "schemeId": "MED_FS2013",
           "claimId": "claim_123",
           "feeCalculation": {
-            "totalAmount": 321.93,
+            "totalAmount": 321.85,
             "vatIndicator": true,
             "vatRateApplied": 20.00,
             "calculatedVatAmount": 33.60,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": 168.00
           }
         }
@@ -300,7 +300,7 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "startDate": "2021-11-05",
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "boltOns": {
             "boltOnAdjournedHearing": 3.00
@@ -316,14 +316,14 @@ class FeeCalculationFixedFeeIntegrationTest extends BaseFeeCalculationIntegratio
           "claimId": "claim_123",
           "escapeCaseFlag": false,
           "feeCalculation": {
-            "totalAmount": 1081.53,
+            "totalAmount": 1081.45,
             "vatIndicator": true,
             "vatRateApplied": 20.00,
             "calculatedVatAmount": 160.20,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "fixedFeeAmount": 450.00,
             "boltOnFeeDetails": {
               "boltOnTotalFeeAmount": 351.00,

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
@@ -379,20 +379,27 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "schemeId": "POL_FS2022",
           "claimId": "claim_123",
           "feeCalculation": {
-            "totalAmount": 148.12,
+            "totalAmount": 138.07,
             "vatIndicator": true,
             "vatRateApplied": 20.0,
             "calculatedVatAmount": 12.91,
             "disbursementAmount": 50.5,
             "requestedNetDisbursementAmount": 50.5,
-            "disbursementVatAmount": 20.15,
+            "disbursementVatAmount": 10.1,
             "requestedDisbursementVatAmount": 20.15,
             "hourlyTotalAmount": 115.06,
             "netProfitCostsAmount": 34.56,
             "requestedNetProfitCostsAmount": 34.56,
             "netTravelCostsAmount": 20.0,
             "netWaitingCostsAmount": 10.0
-          }
+          },
+          "validationMessages": [
+            {
+              "code": "WARALL1",
+              "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable.",
+              "type": "WARNING"
+            }
+          ]
         }
         """);
   }

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationHourlyRateIntegrationTest.java
@@ -173,7 +173,7 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 239.06,
           "netCostOfCounsel": 79.19,
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "caseConcludedDate": "2026-02-01"
         }
@@ -186,14 +186,14 @@ class FeeCalculationHourlyRateIntegrationTest extends BaseFeeCalculationIntegrat
           "claimId": "claim_123",
           "escapeCaseFlag": false,
           "feeCalculation": {
-            "totalAmount": 502.23,
+            "totalAmount": 502.15,
             "vatIndicator": true,
             "vatRateApplied": 20.00,
             "calculatedVatAmount": 63.65,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "hourlyTotalAmount": 318.25,
             "netCostOfCounselAmount": 79.19,
             "netProfitCostsAmount": 239.06,

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
@@ -761,11 +761,11 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
   @ParameterizedTest
   @CsvSource({
     "IMCF, WARIA1, Costs have been capped at £600 without an Immigration Priority Authority Number. "
-        + "Disbursement costs exceed the Disbursement Limit., false, 2173.72, 250.6, 650.0, 600.0, 1092.0, 0",
+        + "Disbursement costs exceed the Disbursement Limit., false, 2113.60, 250.6, 650.0, 600.0, 1092.0, 0",
     "IALB, WARIA2, Costs have been capped at £400 without an Immigration Priority Authority Number. "
-        + "Disbursement costs exceed the Disbursement Limit., false, 1158.92, 114.8, 450.0, 400.0, 413.0, 0",
+        + "Disbursement costs exceed the Disbursement Limit., false, 1098.80, 114.8, 450.0, 400.0, 413.0, 0",
     "IACE, WARIA3, The claim exceeds the Escape Case Threshold. "
-        + "An Escape Case Claim must be submitted for further costs to be paid., true, 1116.12, 166.0, 50.0, 50.0, 669.0, 1500"
+        + "An Escape Case Claim must be submitted for further costs to be paid., true, 1056.00, 166.0, 50.0, 50.0, 669.0, 1500"
   })
   void shouldReturnValidationWarningForImmigrationAndAsylumFixedFee(
       String feeCode,
@@ -786,7 +786,7 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "claimId": "claim_123",
           "startDate": "2024-09-30",
           "netDisbursementAmount": %s,
-          "disbursementVatAmount": 70.12,
+          "disbursementVatAmount": 10.00,
           "vatIndicator": true,
           "detentionTravelAndWaitingCosts": 111.00,
           "jrFormFilling": 50.00,
@@ -818,8 +818,8 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
             "calculatedVatAmount": %s,
             "requestedNetDisbursementAmount": %s,
             "disbursementAmount": %s,
-            "disbursementVatAmount": 70.12,
-            "requestedDisbursementVatAmount": 70.12,
+            "disbursementVatAmount": 10.00,
+            "requestedDisbursementVatAmount": 10.00,
             "fixedFeeAmount": %s,
             "detentionTravelAndWaitingCostsAmount": 111.0,
             "jrFormFillingAmount": 50.0

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
@@ -1088,13 +1088,18 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
               "type": "WARNING",
               "code": "WARIA11",
               "message": "Costs have been capped without an Immigration Priority Authority Number. Disbursement costs exceed the Disbursement Limit."
+            },
+            {
+              "type": "WARNING",
+              "code": "WARALL1",
+              "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable."
             }
           ],
           "feeCalculation": {
-            "totalAmount": 2000.0,
+            "totalAmount": 1920.0,
             "disbursementAmount": 1600.0,
             "requestedNetDisbursementAmount": 2000.0,
-            "disbursementVatAmount": 400.0,
+            "disbursementVatAmount": 320.0,
             "requestedDisbursementVatAmount": 400.0
           }
         }

--- a/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
+++ b/scheme-service/src/integrationTest/java/uk/gov/justice/laa/fee/scheme/api/feecalculation/FeeCalculationValidationIntegrationTest.java
@@ -1516,7 +1516,7 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           "netProfitCosts": 900,
           "netCostOfCounsel": 79.19,
           "netDisbursementAmount": 100.21,
-          "disbursementVatAmount": 20.12,
+          "disbursementVatAmount": 20.04,
           "vatIndicator": true,
           "caseConcludedDate": "2026-02-01"
         }
@@ -1538,18 +1538,77 @@ class FeeCalculationValidationIntegrationTest extends BaseFeeCalculationIntegrat
           ],
           "escapeCaseFlag": true,
           "feeCalculation": {
-            "totalAmount": 960.33,
+            "totalAmount": 960.25,
             "vatIndicator": true,
             "vatRateApplied": 20.0,
             "calculatedVatAmount": 140.0,
             "disbursementAmount": 100.21,
             "requestedNetDisbursementAmount": 100.21,
-            "disbursementVatAmount": 20.12,
-            "requestedDisbursementVatAmount": 20.12,
+            "disbursementVatAmount": 20.04,
+            "requestedDisbursementVatAmount": 20.04,
             "hourlyTotalAmount": 700.0,
             "netProfitCostsAmount": 900.0,
             "requestedNetProfitCostsAmount": 900.0,
             "netCostOfCounselAmount": 79.19
+          }
+        }
+        """);
+  }
+
+  @Test
+  void shouldReturnValidationWarningForDisbursementVatLimit() throws Exception {
+    String request = """ 
+        {
+          "feeCode": "MHL03",
+          "claimId": "claim_123",
+          "startDate": "2025-02-01",
+          "caseConcludedDate": "2025-02-01",
+          "netDisbursementAmount": 123.38,
+          "disbursementVatAmount": 80.00,
+          "netProfitCosts": 1000,
+          "netCostOfCounsel": 500,
+          "vatIndicator": true,
+          "boltOns": {
+              "boltOnAdjournedHearing": 1
+          }
+        }
+        """;
+
+    postAndExpect(
+        request,
+        """
+        {
+          "feeCode": "MHL03",
+          "claimId": "claim_123",
+          "schemeId": "MHL_FS2013",
+          "validationMessages": [
+              {
+                  "type": "WARNING",
+                  "code": "WARALL1",
+                  "message": "Value entered exceeds the VAT threshold for the net disbursement amount claimed. Costs have been capped at the maximum VAT amount claimable."
+              },
+              {
+                  "type": "WARNING",
+                  "code": "WARMH1",
+                  "message": "The claim exceeds the Escape Case Threshold. An Escape Case Claim must be submitted for further costs to be paid."
+              }
+          ],
+          "escapeCaseFlag": true,
+          "feeCalculation": {
+              "totalAmount": 828.46,
+              "vatIndicator": true,
+              "vatRateApplied": 20.0,
+              "calculatedVatAmount": 113.4,
+              "disbursementAmount": 123.38,
+              "requestedNetDisbursementAmount": 123.38,
+              "disbursementVatAmount": 24.68,
+              "requestedDisbursementVatAmount": 80.0,
+              "fixedFeeAmount": 450.0,
+              "boltOnFeeDetails": {
+                  "boltOnTotalFeeAmount": 117.0,
+                  "boltOnAdjournedHearingCount": 1,
+                  "boltOnAdjournedHearingFee": 117.0
+              }
           }
         }
         """);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/enums/WarningType.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/enums/WarningType.java
@@ -25,6 +25,11 @@ public enum WarningType {
 
   WARN_DEBT_ESCAPE_THRESHOLD("WAROTH5", getEscapeMessage(), CategoryType.DEBT),
 
+  WARN_DISBURSEMENT_VAT_CAPPED(
+      "WARALL1",
+      "Value entered exceeds the VAT threshold for the net disbursement amount claimed. "
+          + "Costs have been capped at the maximum VAT amount claimable."),
+
   WARN_DISCRIMINATION_ESCAPE_THRESHOLD("WAROTH1", getEscapeMessage(), CategoryType.DISCRIMINATION),
 
   WARN_EDUCATION_ESCAPE_THRESHOLD("WAROTH7", getEscapeMessage(), CategoryType.EDUCATION),

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/GlobalExceptionHandler.java
@@ -118,6 +118,18 @@ public class GlobalExceptionHandler {
   }
 
   /**
+   * Global exception handler for VatRateNotFoundException exception.
+   * No VAT rate exists for the date derived from the request.
+   *
+   * @param ex the exception thrown when no VAT rate is found for the given date.
+   * @return the error response and a 404 Not Found status code.
+   */
+  @ExceptionHandler(VatRateNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleVatRateNotFound(VatRateNotFoundException ex) {
+    return handleException("VAT rate not found error", ex, HttpStatus.NOT_FOUND);
+  }
+
+  /**
    * Global exception handler for StartDateRequiredException exception.
    * Start date is required for fee calculation but was not provided in the request.
    *

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/VatRateNotFoundException.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/exception/VatRateNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.justice.laa.fee.scheme.exception;
+
+import java.time.LocalDate;
+
+/**
+ * Exception when no VAT rate is found for the supplied date.
+ */
+public class VatRateNotFoundException extends RuntimeException {
+  public VatRateNotFoundException(LocalDate date) {
+    super(String.format("No VAT rate found for date: %s", date));
+  }
+}

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/disbursement/ImmigrationAsylumDisbursementOnlyCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/disbursement/ImmigrationAsylumDisbursementOnlyCalculator.java
@@ -4,6 +4,8 @@ import static java.util.Objects.nonNull;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_ONLY;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -13,6 +15,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
@@ -23,13 +26,17 @@ import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
+import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
  * Calculate the Immigration and asylum disbursement only fee for a given fee entity and fee calculation request.
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ImmigrationAsylumDisbursementOnlyCalculator implements FeeCalculator {
+
+  private final VatRatesService vatRatesService;
 
   @Override
   public Set<CategoryType> getSupportedCategories() {
@@ -37,7 +44,7 @@ public class ImmigrationAsylumDisbursementOnlyCalculator implements FeeCalculato
   }
 
   /**
-   * Calculated fee for Immigration and asylum disbursement only fee based on the provided fee entity and fee calculation request.
+   * Calculated fee for Immigration and asylum disbursement only fee based on the provided fee entity and request.
    */
   @Override
   public FeeCalculationResponse calculate(FeeCalculationRequest feeCalculationRequest, FeeEntity feeEntity) {
@@ -45,7 +52,6 @@ public class ImmigrationAsylumDisbursementOnlyCalculator implements FeeCalculato
     log.info("Calculate Immigration and Asylum disbursements only");
 
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
     String immigrationPriorAuthorityNumber = feeCalculationRequest.getImmigrationPriorAuthorityNumber();
 
     List<ValidationMessagesInner> validationMessages = new ArrayList<>();
@@ -54,14 +60,22 @@ public class ImmigrationAsylumDisbursementOnlyCalculator implements FeeCalculato
     BigDecimal netDisbursementAmount = checkLimitAndCapIfExceeded(requestedNetDisbursementAmount,
         disbursementLimitContext, validationMessages);
 
-    BigDecimal totalAmount = calculateTotalAmount(netDisbursementAmount, requestedDisbursementVatAmount);
+    Double requestedDisbursementVatAmount = feeCalculationRequest.getDisbursementVatAmount();
+    BigDecimal disbursementVatAmount = BigDecimal.ZERO;
+    if (requestedDisbursementVatAmount != null) {
+      BigDecimal vatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest));
+      disbursementVatAmount = capDisbursementVat(netDisbursementAmount,
+          toBigDecimal(requestedDisbursementVatAmount), vatRate, validationMessages);
+    }
+
+    BigDecimal totalAmount = calculateTotalAmount(netDisbursementAmount, disbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(netDisbursementAmount) : null)
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
-        .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(nonNull(requestedDisbursementVatAmount) ? toDouble(disbursementVatAmount) : null)
+        .requestedDisbursementVatAmount(requestedDisbursementVatAmount)
         .build();
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculator.java
@@ -5,6 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -64,11 +65,18 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
 
     // Get disbursements
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Validate and cap disbursement VAT
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            netDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount,
-        netDisbursementAmount, disbursementVatAmount);
+        netDisbursementAmount, cappedDisbursementVatAmount);
 
     // Escape case logic
     BigDecimal netProfitCosts = toBigDecimal(feeCalculationRequest.getNetProfitCosts());
@@ -79,7 +87,6 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
         .add(netTravelCosts)
         .add(netWaitingCosts);
 
-    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     boolean isEscaped = isEscapedCase(feeTotal, feeEntity);
 
     if (isEscaped) {
@@ -94,7 +101,7 @@ public class AssociatedCivilFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .build();

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculator.java
@@ -7,7 +7,9 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_ESC
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
@@ -70,8 +72,6 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
     log.info("Get fields from fee calculation request");
     // get the requested disbursement amount from feeCalculationRequest
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    // get the requested disbursement VAT amount from feeCalculationRequest
-    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
     // get the requested detentionTravelAndWaitingCosts amount from feeCalculationRequest
     BigDecimal requestedDetentionTravelAndWaitingCosts = toBigDecimal(feeCalculationRequest.getDetentionTravelAndWaitingCosts());
     // get the requested jrFormFilling amount from feeCalculationRequest
@@ -110,9 +110,13 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
 
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
+    // cap the disbursement VAT at the applicable rate of the (capped) net disbursement
+    BigDecimal disbursementVatAmount =
+        capDisbursementVatForRequest(feeCalculationRequest, netDisbursementAmount, validationMessages);
+
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAndAdditionalCosts,
-        calculatedVatAmount, netDisbursementAmount, requestedDisbursementVatAmount);
+        calculatedVatAmount, netDisbursementAmount, disbursementVatAmount);
 
     boolean escapeCaseFlag = false;
     if (!FEE_CODES_NO_DISBURSEMENT_LIMIT_AND_NO_ESCAPE.contains(feeCalculationRequest.getFeeCode())) {
@@ -127,7 +131,7 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(netDisbursementAmount) : null)
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(nonNull(feeCalculationRequest.getDisbursementVatAmount()) ? toDouble(disbursementVatAmount) : null)
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .detentionTravelAndWaitingCostsAmount(feeCalculationRequest.getDetentionTravelAndWaitingCosts())
@@ -136,6 +140,20 @@ public final class ImmigrationAsylumFixedFeeCalculator implements FeeCalculator 
         .build();
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages, escapeCaseFlag);
+  }
+
+  /**
+   * Cap the disbursement VAT at the VAT rate (looked up by case concluded date) applied to the net disbursement.
+   */
+  private BigDecimal capDisbursementVatForRequest(FeeCalculationRequest feeCalculationRequest,
+      BigDecimal netDisbursementAmount, List<ValidationMessagesInner> validationMessages) {
+    BigDecimal requestedDisbursementVat = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    if (BigDecimal.ZERO.compareTo(requestedDisbursementVat) == 0) {
+      return BigDecimal.ZERO;
+    }
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest));
+    return capDisbursementVat(netDisbursementAmount, requestedDisbursementVat,
+        disbursementVatRate, validationMessages);
   }
 
   /**

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculator.java
@@ -4,6 +4,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.MEDIATION;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getFeeClaimStartDate;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -11,6 +12,8 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +27,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
@@ -83,6 +87,7 @@ public class MediationFixedFeeCalculator implements FeeCalculator {
 
     log.info("Get fields from fee calculation request");
 
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
 
     // TODO: Revisit the logic below when ticket LFSP-533 is taken up for development.
     // Calculate VAT if applicable
@@ -93,10 +98,16 @@ public class MediationFixedFeeCalculator implements FeeCalculator {
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    //TODO: change to case concluded date when approved
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(feeCalculationRequest.getStartDate(), true);
+    BigDecimal cappedDisbursementVatAmount =
+            capDisbursementVat(
+                    netDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount,
-        netDisbursementAmount, disbursementVatAmount);
+            netDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -105,11 +116,11 @@ public class MediationFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .build();
 
-    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation);
+    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculator.java
@@ -6,7 +6,9 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -57,6 +59,8 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
 
     log.info("Calculate Mediation fixed fee");
 
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+
     BoltOnFeeDetails boltOnFeeDetails = BoltOnUtil.calculateBoltOnAmounts(feeCalculationRequest, feeEntity);
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
     BigDecimal fixedFeeAndAdditionalCosts = fixedFeeAmount
@@ -68,15 +72,19 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAndAdditionalCosts, vatRate);
 
     // Get disbursements
-    BigDecimal requestNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
     BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest), true);
+    BigDecimal cappedDisbursementVatAmount =
+            capDisbursementVat(
+                    netDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAndAdditionalCosts, calculatedVatAmount,
-        requestNetDisbursementAmount, requestedDisbursementVatAmount);
+            netDisbursementAmount, cappedDisbursementVatAmount);
 
     // Escape case logic
-    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     boolean escapeCaseFlag = false;
     if (nonNull(feeEntity.getEscapeThresholdLimit())) {
       escapeCaseFlag = isEscaped(feeCalculationRequest, feeEntity, boltOnFeeDetails, validationMessages);
@@ -89,7 +97,7 @@ public class MentalHealthFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .boltOnFeeDetails(filterBoltOnFeeDetails(boltOnFeeDetails))

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculator.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
@@ -84,16 +85,22 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
 
     // Calculate VAT if applicable
     BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
-
     BigDecimal calculatedVatAmount = calculateVatAmount(fixedFeeAmount, vatRate);
 
     // Get disbursements
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Validate and cap disbursement VAT (only when VAT applies)
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            requestedNetDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount,
-        requestedNetDisbursementAmount, disbursementVatAmount);
+        requestedNetDisbursementAmount, cappedDisbursementVatAmount);
 
     // Calculate Amount for Escape case
 
@@ -106,7 +113,6 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
     BigDecimal escapeTotalAmount = netProfitCosts.add(netTravelCosts).add(netWaitingCosts);
 
     // Escape case logic
-    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     boolean isEscaped = isEscapedCase(escapeTotalAmount, policeStationFeesEntity.getEscapeThreshold());
 
     if (isEscaped) {
@@ -121,7 +127,7 @@ public class PoliceStationFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .build();

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculator.java
@@ -3,12 +3,15 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.defaultToZeroIfNull;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +22,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
@@ -57,9 +61,16 @@ public class UndesignatedCourtFixedFeeCalculator implements FeeCalculator {
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
     BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
 
+    // Validate and cap disbursement VAT
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            requestedNetDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
+
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAndAdditionalCosts, calculatedVatAmount,
-        requestedNetDisbursementAmount, requestedDisbursementVatAmount);
+        requestedNetDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -68,14 +79,14 @@ public class UndesignatedCourtFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .netWaitingCostsAmount(feeCalculationRequest.getNetWaitingCosts())
         .netTravelCostsAmount(feeCalculationRequest.getNetTravelCosts())
         .build();
 
-    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation);
+    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
 
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/DesignatedCourtFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/DesignatedCourtFixedFeeCalculator.java
@@ -1,9 +1,16 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard;
 
+import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
+
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
@@ -20,6 +27,23 @@ public class DesignatedCourtFixedFeeCalculator extends StandardFixedFeeCalculato
   @Override
   public Set<CategoryType> getSupportedCategories() {
     return Set.of();
+  }
+
+  @Override
+  protected BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest,
+                                          VatRatesService vatRatesService,
+                                          List<ValidationMessagesInner> validationMessages) {
+
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Calculate disbursed vat amount
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    disbursementVatAmount =
+        FeeCalculationUtil.capDisbursementVat(
+            netDisbursementAmount, disbursementVatAmount, disbursementVatRate, validationMessages);
+
+    return disbursementVatAmount;
   }
 
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/FamilyFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/FamilyFixedFeeCalculator.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.FAMILY;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_FAMILY_ESCAPE_THRESHOLD;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 
@@ -12,6 +13,7 @@ import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
@@ -49,5 +51,23 @@ public class FamilyFixedFeeCalculator extends StandardFixedFeeCalculator {
     }
 
     return escaped;
+  }
+
+  @Override
+  protected BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest,
+                                                VatRatesService vatRatesService,
+                                                List<ValidationMessagesInner> validationMessages) {
+
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Calculate disbursed vat amount
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(
+            getCaseConcludedDate(feeCalculationRequest), true);
+    disbursementVatAmount =
+            FeeCalculationUtil.capDisbursementVat(
+                  netDisbursementAmount, disbursementVatAmount, disbursementVatRate, validationMessages);
+
+    return disbursementVatAmount;
   }
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/OtherCivilFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/OtherCivilFixedFeeCalculator.java
@@ -10,6 +10,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.MISCELLANEOUS;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.PUBLIC_LAW;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.WELFARE_BENEFITS;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
 import uk.gov.justice.laa.fee.scheme.enums.WarningType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
@@ -57,4 +59,21 @@ public class OtherCivilFixedFeeCalculator extends StandardFixedFeeCalculator {
     return escaped;
   }
 
+  @Override
+  protected BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest,
+                                          VatRatesService vatRatesService,
+                                          List<ValidationMessagesInner> validationMessages) {
+
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Calculate disbursed vat amount
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(
+            getCaseConcludedDate(feeCalculationRequest), true);
+    disbursementVatAmount =
+            FeeCalculationUtil.capDisbursementVat(
+                    netDisbursementAmount, disbursementVatAmount, disbursementVatRate, validationMessages);
+
+    return disbursementVatAmount;
+  }
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/PrisonLawFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/PrisonLawFixedFeeCalculator.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
@@ -86,6 +87,23 @@ public class PrisonLawFixedFeeCalculator extends StandardFixedFeeCalculator {
     }
     log.warn("Case has not escaped");
     return false;
+  }
+
+  @Override
+  protected BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest,
+                                          VatRatesService vatRatesService,
+                                          List<ValidationMessagesInner> validationMessages) {
+
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Calculate disbursed vat amount
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    disbursementVatAmount =
+        FeeCalculationUtil.capDisbursementVat(
+            netDisbursementAmount, disbursementVatAmount, disbursementVatRate, validationMessages);
+
+    return disbursementVatAmount;
   }
 
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/SendingHearingFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/SendingHearingFixedFeeCalculator.java
@@ -1,10 +1,16 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard;
 
+import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
+import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
@@ -21,6 +27,23 @@ public class SendingHearingFixedFeeCalculator extends StandardFixedFeeCalculator
   @Override
   public Set<CategoryType> getSupportedCategories() {
     return Set.of(CategoryType.SENDING_HEARING);
+  }
+
+  @Override
+  protected BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest,
+                                          VatRatesService vatRatesService,
+                                          List<ValidationMessagesInner> validationMessages) {
+
+    BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
+    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
+    // Calculate disbursed vat amount
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    disbursementVatAmount =
+        FeeCalculationUtil.capDisbursementVat(
+            netDisbursementAmount, disbursementVatAmount, disbursementVatRate, validationMessages);
+
+    return disbursementVatAmount;
   }
 
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/standard/StandardFixedFeeCalculator.java
@@ -37,6 +37,8 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
 
     log.info("Starting fee calculation for {}", feeEntity.getCategoryType());
 
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+
     //Step 1: get Fixed Fee Amount
     BigDecimal fixedFeeAmount = defaultToZeroIfNull(feeEntity.getFixedFee());
 
@@ -48,14 +50,13 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
 
     //Step 4: get Disbursements
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, vatRatesService, validationMessages);
 
     //Step 5: calculate Total Amount
     BigDecimal totalAmount = calculateTotalAmount(fixedFeeAmount, calculatedVatAmount, netDisbursementAmount,
-        disbursementVatAmount);
+        cappedDisbursementVatAmount);
 
     //Step 6: check if escaped, if eligible
-    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
     boolean isEscaped = false;
     if (canEscape) {
       isEscaped = handleEscapeCase(feeCalculationRequest, feeEntity, validationMessages);
@@ -69,7 +70,7 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(toDoubleOrNull(netDisbursementAmount))
         .requestedNetDisbursementAmount(toDoubleOrNull(netDisbursementAmount))
-        .disbursementVatAmount(toDoubleOrNull(disbursementVatAmount))
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .fixedFeeAmount(toDouble(fixedFeeAmount))
         .build();
@@ -89,5 +90,12 @@ public abstract class StandardFixedFeeCalculator implements FeeCalculator {
   protected boolean handleEscapeCase(FeeCalculationRequest feeCalculationRequest, FeeEntity feeEntity,
                                      List<ValidationMessagesInner> messages) {
     return false;
+  }
+
+  protected BigDecimal capDisbursementVat(
+          FeeCalculationRequest feeCalculationRequest,
+          VatRatesService vatRatesService,
+          List<ValidationMessagesInner> validationMessages) {
+    return toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
   }
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculator.java
@@ -4,11 +4,14 @@ import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ADVICE_ASSISTANCE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +22,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 /**
@@ -45,6 +49,8 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
 
     log.info("Calculate Advice and Assistance and Advocacy Assistance by a court Duty Solicitor hourly rate fee");
 
+    List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+
     BigDecimal requestedNetProfitCosts = toBigDecimal(feeCalculationRequest.getNetProfitCosts());
     BigDecimal requestedNetDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
     BigDecimal requestedNetDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
@@ -60,9 +66,15 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
 
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
+    // Validate and cap disbursement VAT (only when VAT applies)
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            requestedNetDisbursementAmount, requestedNetDisbursementVatAmount, disbursementVatRate, validationMessages);
+
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(profitAndAdditionalCosts,
-        calculatedVatAmount, requestedNetDisbursementAmount, requestedNetDisbursementVatAmount);
+        calculatedVatAmount, requestedNetDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -71,7 +83,7 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(profitAndAdditionalCosts))
         .netProfitCostsAmount(feeCalculationRequest.getNetProfitCosts())
@@ -80,6 +92,6 @@ public class AdviceAssistanceAdvocacyHourlyRateCalculator implements FeeCalculat
         .netTravelCostsAmount(feeCalculationRequest.getNetTravelCosts())
         .build();
 
-    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation);
+    return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
 }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculator.java
@@ -5,6 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ADVOCACY_APPE
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -73,9 +74,16 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
 
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
+    // Validate and cap disbursement VAT (only when VAT applies)
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            requestedNetDisbursementAmount, requestedNetDisbursementVatAmount, disbursementVatRate, validationMessages);
+
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(profitAndAdditionalCosts,
-        calculatedVatAmount, requestedNetDisbursementAmount, requestedNetDisbursementVatAmount);
+        calculatedVatAmount, requestedNetDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -84,7 +92,7 @@ public class AdvocacyAppealsReviewsHourlyRateCalculator implements FeeCalculator
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(profitAndAdditionalCosts))
         .netProfitCostsAmount(feeCalculationRequest.getNetProfitCosts())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculator.java
@@ -6,6 +6,8 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isEscapedCase;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -73,16 +75,19 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
 
     // Calculate VAT if applicable
     BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
-
     BigDecimal calculatedVatAmount = calculateVatAmount(feeTotal, vatRate);
 
     // Get disbursements
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest), true);
+    BigDecimal cappedDisbursementVatAmount =
+            capDisbursementVat(
+                    netDisbursementAmount, requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     // Calculate total amount
     BigDecimal totalAmount = calculateTotalAmount(feeTotal, calculatedVatAmount,
-            netDisbursementAmount, disbursementVatAmount);
+            netDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -92,7 +97,7 @@ public class DiscriminationHourlyRateCalculator implements FeeCalculator {
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         // disbursement not capped, so requested and calculated will be same
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(feeTotal))
         .netCostOfCounselAmount(feeCalculationRequest.getNetCostOfCounsel())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
@@ -12,6 +12,7 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.PROFIT_COST;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.TOTAL;
@@ -32,6 +33,7 @@ import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
 import uk.gov.justice.laa.fee.scheme.enums.WarningType;
 import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
 import uk.gov.justice.laa.fee.scheme.feecalculator.util.boltons.BoltOnUtil;
 import uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitContext;
 import uk.gov.justice.laa.fee.scheme.model.BoltOnFeeDetails;
@@ -132,13 +134,13 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     // VAT is calculated on net profit costs only
     BigDecimal calculatedVatAmount = calculateVatAmount(netProfitCosts, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotal, netProfitCosts, false, null);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotal, netProfitCosts, false, null);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -176,13 +178,13 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotal, netProfitCosts, true, null);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotal, netProfitCosts, true, null);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -233,13 +235,14 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotalWithBoltsOn.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotalWithBoltsOn.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotalWithBoltsOn, netProfitCosts, true, boltOnFeeDetails);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotalWithBoltsOn,
+        netProfitCosts, true, boltOnFeeDetails);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -262,11 +265,21 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     }
   }
 
+  private BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest, List<ValidationMessagesInner> validationMessages) {
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest), true);
+    return FeeCalculationUtil.capDisbursementVat(
+            toBigDecimal(feeCalculationRequest.getNetDisbursementAmount()),
+            toBigDecimal(feeCalculationRequest.getDisbursementVatAmount()),
+            disbursementVatRate,
+            validationMessages);
+  }
+
   private FeeCalculation buildFeeCalculation(FeeCalculationRequest feeCalculationRequest,
                                              BigDecimal totalAmount,
                                              BigDecimal vatRate,
                                              BigDecimal calculatedVatAmount,
                                              BigDecimal disbursementAmount,
+                                             BigDecimal cappedDisbursementVatAmount,
                                              BigDecimal hourlyTotalAmount,
                                              BigDecimal netProfitCostsAmount,
                                              boolean includeCostOfCounsel,
@@ -278,7 +291,7 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(disbursementAmount) : null)
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(hourlyTotalAmount))
         .netProfitCostsAmount(nonNull(feeCalculationRequest.getNetProfitCosts()) ? toDouble(netProfitCostsAmount) : null)

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculator.java
@@ -4,6 +4,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_POLICE_OTHER_
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -57,7 +58,6 @@ public class PoliceStationHourlyRateCalculator implements FeeCalculator {
     BigDecimal netProfitCosts = toBigDecimal(feeCalculationRequest.getNetProfitCosts());
 
     BigDecimal netDisbursementAmount = toBigDecimal(feeCalculationRequest.getNetDisbursementAmount());
-
     BigDecimal travelCosts = toBigDecimal(feeCalculationRequest.getNetTravelCosts());
 
     BigDecimal waitingCosts = toBigDecimal(feeCalculationRequest.getNetWaitingCosts());
@@ -71,14 +71,21 @@ public class PoliceStationHourlyRateCalculator implements FeeCalculator {
           "Fee total exceeds upper cost limit"));
     }
 
+    BigDecimal requestedDisbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+
     // Calculate VAT if applicable
     BigDecimal vatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest);
     BigDecimal calculatedVatAmount = calculateVatAmount(vatEligibleFeeTotal, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    // Retrieve VAT rate for disbursement vat
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+
+    // Validate and cap disbursement VAT
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(netDisbursementAmount,
+        requestedDisbursementVatAmount, disbursementVatRate, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -86,9 +93,8 @@ public class PoliceStationHourlyRateCalculator implements FeeCalculator {
         .vatRateApplied(toDoubleOrNull(vatRate))
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        // disbursement not capped, so requested and calculated will be same
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(feeTotal))
         .netTravelCostsAmount(feeCalculationRequest.getNetTravelCosts())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculator.java
@@ -5,6 +5,7 @@ import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_PREORDER_C
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateTotalAmount;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.isOverUpperCostLimit;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toBigDecimal;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
@@ -73,8 +74,14 @@ public class PreOrderCoverHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal calculatedVatAmount = calculateVatAmount(profitAndAdditionalCosts, vatRate);
 
+    // Validate and cap disbursement VAT
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForRequest(feeCalculationRequest, Boolean.TRUE);
+    BigDecimal cappedDisbursementVatAmount =
+        capDisbursementVat(
+            requestedNetDisbursementAmount, requestedNetDisbursementVatAmount, disbursementVatRate, validationMessages);
+
     BigDecimal totalAmount = calculateTotalAmount(profitAndAdditionalCosts,
-        calculatedVatAmount, requestedNetDisbursementAmount, requestedNetDisbursementVatAmount);
+        calculatedVatAmount, requestedNetDisbursementAmount, cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = FeeCalculation.builder()
         .totalAmount(toDouble(totalAmount))
@@ -83,7 +90,7 @@ public class PreOrderCoverHourlyRateCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDoubleOrNull(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(profitAndAdditionalCosts))
         .netProfitCostsAmount(feeCalculationRequest.getNetProfitCosts())

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtil.java
@@ -5,6 +5,9 @@ import static uk.gov.justice.laa.fee.scheme.enums.ClaimStartDateType.CASE_CONCLU
 import static uk.gov.justice.laa.fee.scheme.enums.ClaimStartDateType.CASE_START_DATE;
 import static uk.gov.justice.laa.fee.scheme.enums.ClaimStartDateType.REP_ORDER_DATE;
 import static uk.gov.justice.laa.fee.scheme.enums.ClaimStartDateType.UFN;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT_VAT;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitUtil.checkLimitAndCapIfExceeded;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 import static uk.gov.justice.laa.fee.scheme.service.FeeCodeConstants.FEE_CODE_PROH_TYPE;
 
@@ -24,6 +27,7 @@ import uk.gov.justice.laa.fee.scheme.exception.CaseConcludedDateRequiredExceptio
 import uk.gov.justice.laa.fee.scheme.exception.FeeContext;
 import uk.gov.justice.laa.fee.scheme.exception.StartDateRequiredException;
 import uk.gov.justice.laa.fee.scheme.exception.ValidationException;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitContext;
 import uk.gov.justice.laa.fee.scheme.model.BoltOnFeeDetails;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
@@ -114,12 +118,8 @@ public final class FeeCalculationUtil {
    * @return LocalDate
    */
   public static LocalDate getCaseConcludedDate(FeeCalculationRequest feeCalculationRequest) {
-
-    Boolean isVatRequired = feeCalculationRequest.getVatIndicator();
-    if (isVatRequired != null && isVatRequired && feeCalculationRequest.getCaseConcludedDate() == null) {
-      throw new CaseConcludedDateRequiredException(feeCalculationRequest.getFeeCode());
-    }
-    return feeCalculationRequest.getCaseConcludedDate();
+    return Optional.ofNullable(feeCalculationRequest.getCaseConcludedDate())
+        .orElseThrow(() -> new CaseConcludedDateRequiredException(feeCalculationRequest.getFeeCode()));
   }
 
   /**
@@ -156,6 +156,16 @@ public final class FeeCalculationUtil {
         .add(disbursementVatAmount);
   }
 
+  /**
+   * Cap the disbursement VAT at the maximum claimable and add a warning if it is exceeded.
+   */
+  public static BigDecimal capDisbursementVat(BigDecimal netDisbursementAmount, BigDecimal requestedDisbursementVat,
+                                              BigDecimal vatRate, List<ValidationMessagesInner> validationMessages) {
+    BigDecimal maxDisbursementVat = calculateVatAmount(netDisbursementAmount, vatRate);
+    LimitContext limitContext =
+        new LimitContext(DISBURSEMENT_VAT, maxDisbursementVat, null, WARN_DISBURSEMENT_VAT_CAPPED);
+    return checkLimitAndCapIfExceeded(requestedDisbursementVat, limitContext, validationMessages);
+  }
 
   /**
    * If bolts ons are null, return null for request.

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/limit/LimitType.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/limit/LimitType.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum LimitType {
   PROFIT_COST("Profit Costs"),
   DISBURSEMENT("Disbursements"),
+  DISBURSEMENT_VAT("Disbursement VAT"),
   TOTAL("Total");
 
   private final String displayName;

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
@@ -36,11 +36,20 @@ public class VatRatesService {
       return BigDecimal.ZERO;
     }
 
+    return getVatRateForDate(date);
+  }
+
+  /**
+   * Returns the VAT rate applicable for a given date, regardless of the VAT indicator.
+   *
+   * @param date the date to apply the VAT
+   * @return the VAT rate
+   */
+  public BigDecimal getVatRateForDate(LocalDate date) {
     VatRatesEntity vatRatesEntity = vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date);
-    BigDecimal vatRate = vatRatesEntity.getVatRate();
 
     log.info("Retrieved VAT Rate: {}", vatRatesEntity.getVatRate());
-    return vatRate;
+    return vatRatesEntity.getVatRate();
   }
 
   /**

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
@@ -4,11 +4,13 @@ import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUti
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
+import uk.gov.justice.laa.fee.scheme.exception.VatRateNotFoundException;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
@@ -46,7 +48,9 @@ public class VatRatesService {
    * @return the VAT rate
    */
   public BigDecimal getVatRateForDate(LocalDate date) {
-    VatRatesEntity vatRatesEntity = vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date);
+    VatRatesEntity vatRatesEntity =
+        Optional.ofNullable(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date))
+            .orElseThrow(() -> new VatRateNotFoundException(date));
 
     log.info("Retrieved VAT Rate: {}", vatRatesEntity.getVatRate());
     return vatRatesEntity.getVatRate();

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/service/VatRatesService.java
@@ -52,6 +52,7 @@ public class VatRatesService {
     return vatRatesEntity.getVatRate();
   }
 
+
   /**
    * Returns the VAT rate derived from the fee calculation request,
    * resolving the case concluded date and VAT indicator from the request.
@@ -62,5 +63,18 @@ public class VatRatesService {
   public BigDecimal getVatRateForRequest(FeeCalculationRequest feeCalculationRequest) {
     LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
     return getVatRateForDate(caseConcludedDate, feeCalculationRequest.getVatIndicator());
+  }
+
+  /**
+   * Returns the VAT rate derived from the fee calculation request,
+   * resolving the case concluded date and VAT indicator from the request.
+   *
+   * @param feeCalculationRequest the fee calculation request
+   * @param vatIndicator          indicates whether VAT is applicable, if true returns VAT rate otherwise BigDecimal.ZERO
+   * @return the VAT rate
+   */
+  public BigDecimal getVatRateForRequest(FeeCalculationRequest feeCalculationRequest, Boolean vatIndicator) {
+    LocalDate caseConcludedDate = getCaseConcludedDate(feeCalculationRequest);
+    return getVatRateForDate(caseConcludedDate, vatIndicator);
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -31,11 +31,6 @@ public abstract class BaseFeeCalculatorTest {
 
   protected void mockVatRatesVatIndicatorTrue() {
     when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
-        .thenReturn(new BigDecimal("20.00"));
-  }
-
-  protected void mockVatRatesVatIndicatorTrue() {
-    when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
             .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -24,13 +24,13 @@ public abstract class BaseFeeCalculatorTest {
   protected void mockVatRatesService(Boolean vatIndicator) {
     BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
     lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
-    lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForDate(any())).thenReturn(new BigDecimal("20.00"));
     lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
     lenient().when(vatRatesService.getVatRateForRequest(any(), any())).thenReturn(new BigDecimal("20.00"));
   }
 
   protected void mockVatRatesVatIndicatorTrue() {
     when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
-            .thenReturn(new BigDecimal("20.00"));
+        .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -1,9 +1,12 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,5 +25,11 @@ public abstract class BaseFeeCalculatorTest {
     BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
     lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
     lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForRequest(any(), any())).thenReturn(new BigDecimal("20.00"));
+  }
+
+  protected void mockVatRatesVatIndicatorTrue() {
+    when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
+        .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -24,6 +24,7 @@ public abstract class BaseFeeCalculatorTest {
   protected void mockVatRatesService(Boolean vatIndicator) {
     BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
     lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
     lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
     lenient().when(vatRatesService.getVatRateForRequest(any(), any())).thenReturn(new BigDecimal("20.00"));
   }
@@ -31,5 +32,10 @@ public abstract class BaseFeeCalculatorTest {
   protected void mockVatRatesVatIndicatorTrue() {
     when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
         .thenReturn(new BigDecimal("20.00"));
+  }
+
+  protected void mockVatRatesVatIndicatorTrue() {
+    when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
+            .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/disbursement/ImmigrationAsylumDisbursementOnlyCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/disbursement/ImmigrationAsylumDisbursementOnlyCalculatorTest.java
@@ -1,8 +1,12 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator.disbursement;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.IMMIGRATION_ASYLUM;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.DISB_ONLY;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_ONLY;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
@@ -11,73 +15,77 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
+import uk.gov.justice.laa.fee.scheme.exception.CaseConcludedDateRequiredException;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
+import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 @ExtendWith(MockitoExtension.class)
 class ImmigrationAsylumDisbursementOnlyCalculatorTest {
+
+  @Mock
+  VatRatesService vatRatesService;
 
   @InjectMocks
   ImmigrationAsylumDisbursementOnlyCalculator immigrationAsylumDisbursementOnlyCalculator;
 
   public static Stream<Arguments> testData() {
     return Stream.of(
-        arguments("ICASD, below disbursement limit",
-            "ICASD", null, 1000.0, 200.0,
-            1000.0, 1600.00, 1200.0, false),
-
-        arguments("ICISD, above disbursement limit, with prior authority",
-            "ICISD", "xyz", 1500.0, 200.0,
-            1500.0, 1200.0, 1700.0, false),
-
-        arguments("ICSSD, above disbursement limit, without prior authority",
-            "ICSSD", null, 1111.0, 200.0,
-            600.0, 600.0, 800.0, true),
-
-        arguments("ICSSD, no disbursement claimed",
-            "ICSSD", null, null, null,
-            null, 600.0, 0.0, false)
+        arguments("ICASD", null, 1000.0, 200.0, 1000.0, 1600.0, 200.0, 1200.0, false, false),
+        arguments("ICISD", "xyz", 1500.0, 200.0, 1500.0, 1200.0, 200.0, 1700.0, false, false),
+        arguments("ICSSD", null, 1111.0, 200.0, 600.0, 600.0, 120.0, 720.0, true, true),
+        arguments("ICSSD", null, null, null, null, 600.0, null, 0.0, false, false),
+        arguments("ICASD", null, 500.0, 200.0, 500.0, 1600.0, 100.0, 600.0, false, true)
     );
   }
 
-  private static Arguments arguments(String scenario, String feeCode, String priorAuthority, Double requestedNetDisbursementAmount,
-                                     Double disbursementVatAmount, Double netDisbursementAmount, double netDisbursementLimit,
-                                     double expectedTotal, boolean hasWarning) {
-
-    return Arguments.of(scenario, feeCode, priorAuthority, requestedNetDisbursementAmount, disbursementVatAmount,
-        netDisbursementAmount, netDisbursementLimit, expectedTotal, hasWarning);
+  private static Arguments arguments(String feeCode, String priorAuthority,
+                                     Double requestedNetDisbursementAmount, Double requestedDisbursementVatAmount,
+                                     Double expectedNetDisbursementAmount, double disbursementLimit,
+                                     Double expectedDisbursementVatAmount, double expectedTotal,
+                                     boolean hasNetWarning, boolean hasVatWarning) {
+    return Arguments.of(feeCode, priorAuthority, requestedNetDisbursementAmount, requestedDisbursementVatAmount,
+        expectedNetDisbursementAmount, disbursementLimit, expectedDisbursementVatAmount, expectedTotal,
+        hasNetWarning, hasVatWarning);
   }
 
   @ParameterizedTest
   @MethodSource("testData")
   void calculate_whenImmigrationAndAsylum_withDisbursement(
-      String description,
       String feeCode,
       String immigrationPriorityAuthority,
       Double requestedNetDisbursementAmount,
-      Double disbursementVatAmount,
-      Double netDisbursementAmount,
+      Double requestedDisbursementVatAmount,
+      Double expectedNetDisbursementAmount,
       double disbursementLimit,
+      Double expectedDisbursementVatAmount,
       double expectedTotal,
-      boolean hasWarning
+      boolean hasNetWarning,
+      boolean hasVatWarning
   ) {
+
+    // lenient: the "no disbursement VAT claimed" row never looks up the rate
+    lenient().when(vatRatesService.getVatRateForDate(any(LocalDate.class))).thenReturn(BigDecimal.valueOf(20));
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .claimId("claim_123")
         .startDate(LocalDate.of(2025, 7, 29))
+        .caseConcludedDate(LocalDate.of(2025, 7, 29))
         .netDisbursementAmount(requestedNetDisbursementAmount)
-        .disbursementVatAmount(disbursementVatAmount)
+        .disbursementVatAmount(requestedDisbursementVatAmount)
         .immigrationPriorAuthorityNumber(immigrationPriorityAuthority)
         .build();
 
@@ -92,21 +100,19 @@ class ImmigrationAsylumDisbursementOnlyCalculatorTest {
     FeeCalculationResponse response = immigrationAsylumDisbursementOnlyCalculator.calculate(feeCalculationRequest, feeEntity);
 
     List<ValidationMessagesInner> validationMessages = new ArrayList<>();
-    if (hasWarning) {
-      ValidationMessagesInner validationMessage = ValidationMessagesInner.builder()
-          .code(WARN_IMM_ASYLM_DISB_ONLY.getCode())
-          .message(WARN_IMM_ASYLM_DISB_ONLY.getMessage())
-          .type(WARNING)
-          .build();
-      validationMessages.add(validationMessage);
+    if (hasNetWarning) {
+      validationMessages.add(buildWarning(WARN_IMM_ASYLM_DISB_ONLY.getCode(), WARN_IMM_ASYLM_DISB_ONLY.getMessage()));
+    }
+    if (hasVatWarning) {
+      validationMessages.add(buildWarning(WARN_DISBURSEMENT_VAT_CAPPED.getCode(), WARN_DISBURSEMENT_VAT_CAPPED.getMessage()));
     }
 
     FeeCalculation expectedCalculation = FeeCalculation.builder()
         .totalAmount(expectedTotal)
-        .disbursementAmount(netDisbursementAmount)
+        .disbursementAmount(expectedNetDisbursementAmount)
         .requestedNetDisbursementAmount(requestedNetDisbursementAmount)
-        .disbursementVatAmount(disbursementVatAmount)
-        .requestedDisbursementVatAmount(disbursementVatAmount)
+        .disbursementVatAmount(expectedDisbursementVatAmount)
+        .requestedDisbursementVatAmount(requestedDisbursementVatAmount)
         .build();
 
     FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
@@ -122,4 +128,33 @@ class ImmigrationAsylumDisbursementOnlyCalculatorTest {
         .isEqualTo(expectedResponse);
   }
 
+  @Test
+  void calculate_whenDisbursementVatClaimedWithoutCaseConcludedDate_throws() {
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode("ICASD")
+        .claimId("claim_123")
+        .startDate(LocalDate.of(2025, 7, 29))
+        .netDisbursementAmount(100.0)
+        .disbursementVatAmount(20.0)
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("ICASD")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("IMM_ASYLM_FS2023").build())
+        .categoryType(IMMIGRATION_ASYLUM)
+        .feeType(DISB_ONLY)
+        .disbursementLimit(BigDecimal.valueOf(1600.0))
+        .build();
+
+    assertThatThrownBy(() -> immigrationAsylumDisbursementOnlyCalculator.calculate(feeCalculationRequest, feeEntity))
+        .isInstanceOf(CaseConcludedDateRequiredException.class);
+  }
+
+  private static ValidationMessagesInner buildWarning(String code, String message) {
+    return ValidationMessagesInner.builder()
+        .code(code)
+        .message(message)
+        .type(WARNING)
+        .build();
+  }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/AssociatedCivilFixedFeeCalculatorTest.java
@@ -1,8 +1,12 @@
 package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ASSOCIATED_CIVIL;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ASSOCIATED_CIVIL_ESCAPE_THRESHOLD;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
@@ -13,28 +17,41 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
-import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
 import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
+import uk.gov.justice.laa.fee.scheme.service.VatRatesService;
 
 @ExtendWith(MockitoExtension.class)
-class AssociatedCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
+class AssociatedCivilFixedFeeCalculatorTest {
+
+  @Mock
+  VatRatesService vatRatesService;
 
   @InjectMocks
   AssociatedCivilFixedFeeCalculator associatedCivilFixedFeeCalculator;
 
+  private void mockVatRatesService(Boolean vatIndicator) {
+    BigDecimal vatRate = vatIndicator ? new BigDecimal("20.00") : BigDecimal.ZERO;
+    lenient().when(vatRatesService.getVatRateForDate(any(), any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForRequest(any())).thenReturn(vatRate);
+    lenient().when(vatRatesService.getVatRateForRequest(any(), any())).thenReturn(new BigDecimal("20.00"));
+    // Disbursement VAT is always fetched with Boolean.TRUE regardless of vatIndicator
+    lenient().when(vatRatesService.getVatRateForDate(any(), eq(Boolean.TRUE))).thenReturn(new BigDecimal("20.00"));
+  }
+
   @ParameterizedTest
   @CsvSource({
-      "false, 10.00, 20.00, 170.33, 0",  // Under escape threshold (No VAT)
-      "true, 10.00, 20.00, 180.33, 10.00",  // Under escape threshold limit (VAT applied)
-      "false, 80.00, 20.00, 170.33, 0", // Equal to escape threshold limit (No VAT)
-      "true, 80.00, 20.00, 180.33, 10.00" // Equal to escape threshold limit (VAT applied)
+      "false, 10.00, 20.00, 170.13, 0",  // Under escape threshold (No VAT)
+      "true, 10.00, 20.00, 180.13, 10.00",  // Under escape threshold limit (VAT applied)
+      "false, 80.00, 20.00, 170.13, 0", // Equal to escape threshold limit (No VAT)
+      "true, 80.00, 20.00, 180.13, 10.00" // Equal to escape threshold limit (VAT applied)
   })
   void calculate_shouldReturnFeeCalculationResponse(boolean vatIndicator, double netTravelCosts,
                                                     double netWaitingCosts, double expectedTotal,
@@ -53,8 +70,8 @@ class AssociatedCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource({
-      "false, 90.00, 20.00, 170.33, 0", // Over escape threshold limit (No VAT)
-      "true, 90.00, 20.00, 180.33, 10.00" // Over escape threshold limit (VAT applied)
+      "false, 90.00, 20.00, 170.13, 0", // Over escape threshold limit (No VAT)
+      "true, 90.00, 20.00, 180.13, 10.00" // Over escape threshold limit (VAT applied)
   })
   void calculate_shouldReturnFeeCalculationResponseWithWarning(boolean vatIndicator, double netTravelCosts,
                                                                double netWaitingCosts, double expectedTotal,
@@ -89,7 +106,7 @@ class AssociatedCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .netTravelCosts(netTravelCosts)
         .netWaitingCosts(netWaitingCosts)
         .netDisbursementAmount(100.11)
-        .disbursementVatAmount(20.22)
+        .disbursementVatAmount(20.02)
         .caseConcludedDate(LocalDate.of(2016, 12, 12))
         .build();
   }
@@ -120,8 +137,42 @@ class AssociatedCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(vat);
     assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
     assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
-    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.22);
+    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.02);
     assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(50);
+  }
+
+  @Test
+  void calculate_whenDisbursementVatExceedsCap_shouldReturnWarnDisbursementVatCapped() {
+
+    mockVatRatesService(true);
+
+    // disbursementVatAmount 30.00 > 20% of netDisbursementAmount 100.11 (max = 20.02)
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ASMS")
+        .claimId("claim_123")
+        .uniqueFileNumber("020416/001")
+        .vatIndicator(true)
+        .netProfitCosts(400.00)
+        .netTravelCosts(10.00)
+        .netWaitingCosts(20.00)
+        .netDisbursementAmount(100.11)
+        .disbursementVatAmount(30.00)
+        .caseConcludedDate(LocalDate.of(2016, 12, 12))
+        .build();
+
+    FeeCalculationResponse result = associatedCivilFixedFeeCalculator.calculate(request, buildFeeEntity());
+
+    // fixedFee=50 + vatOnFixed=10 + netDisbAmt=100.11 + cappedDisbVat=20.02 = 180.13
+    assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(180.13);
+    assertThat(result.getFeeCalculation().getDisbursementVatAmount()).isEqualTo(20.02);
+    assertThat(result.getFeeCalculation().getRequestedDisbursementVatAmount()).isEqualTo(30.00);
+    assertThat(result.getValidationMessages()).containsExactly(
+        ValidationMessagesInner.builder()
+            .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .type(WARNING)
+            .build()
+    );
   }
 
   @Test

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/DesignatedCourtFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/DesignatedCourtFixedFeeCalculatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.MAGISTRATES_COURT;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.YOUTH_COURT;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.FIXED;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,11 +23,13 @@ import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
 import uk.gov.justice.laa.fee.scheme.enums.CourtDesignationType;
+import uk.gov.justice.laa.fee.scheme.enums.WarningType;
 import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard.DesignatedCourtFixedFeeCalculator;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class DesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
@@ -159,6 +163,49 @@ class DesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
       assertThat(response).usingRecursiveComparison().isEqualTo(expected);
     }
+  }
+
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "false, 500, 170.13", // No VAT
+      "true, 500, 180.13", // VAT applied
+      "true, null, 180.13" // No escape threshold limit
+  }, nullValues = "null")
+  void calculate_shouldReturnFeeCalculationResponse_withDisbursementLimitWarning(boolean vatIndicator, String escapeThreshold, double expectedTotal) {
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode("PROJ5")
+        .startDate(LocalDate.of(2025, 5, 12))
+        .vatIndicator(vatIndicator)
+        .netDisbursementAmount(100.11)
+        .disbursementVatAmount(22.22)
+        .caseConcludedDate(LocalDate.of(2025, 5, 12))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("PROJ5")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("MAGS_COURT_FS2022").build())
+        .fixedFee(new BigDecimal("50.00"))
+        .escapeThresholdLimit(escapeThreshold != null ? new BigDecimal(escapeThreshold) : null)
+        .categoryType(MAGISTRATES_COURT)
+        .build();
+
+    FeeCalculationResponse result = calculator.calculate(feeCalculationRequest, feeEntity);
+
+    ValidationMessagesInner validationMessage =
+        ValidationMessagesInner.builder()
+            .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .type(WARNING)
+            .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+    assertThat(result).isNotNull();
+    assertThat(result.getFeeCode()).isEqualTo("PROJ5");
+    assertThat(result.getFeeCalculation()).isNotNull();
+    assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
   }
 
   @Test

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/FamilyFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/FamilyFixedFeeCalculatorTest.java
@@ -35,19 +35,23 @@ class FamilyFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource(value = {
-      "false, 500, 170.33", // No VAT
-      "true, 500, 180.33", // VAT applied
-      "true, null, 180.33" // No escape threshold limit
+      "false, 500, 170.13", // No VAT
+      "true, 500, 180.13", // VAT applied
+      "true, null, 180.13" // No escape threshold limit
   }, nullValues = "null")
   void calculate_shouldReturnFeeCalculationResponse(boolean vatIndicator, String escapeThreshold, double expectedTotal) {
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode("COM")
         .startDate(LocalDate.of(2025, 5, 12))
         .vatIndicator(vatIndicator)
         .netDisbursementAmount(100.11)
-        .disbursementVatAmount(20.22)
+        .disbursementVatAmount(20.02)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
@@ -65,6 +69,52 @@ class FamilyFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     assertThat(result.getFeeCode()).isEqualTo("COM");
     assertThat(result.getEscapeCaseFlag()).isFalse();
     assertThat(result.getValidationMessages()).isEmpty();
+    assertThat(result.getFeeCalculation()).isNotNull();
+    assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "false, 500, 170.13", // No VAT
+      "true, 500, 180.13", // VAT applied
+      "true, null, 180.13" // No escape threshold limit
+  }, nullValues = "null")
+  void calculate_shouldReturnFeeCalculationResponse_withDisbursementLimitWarning(boolean vatIndicator, String escapeThreshold, double expectedTotal) {
+    mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("COM")
+            .startDate(LocalDate.of(2025, 5, 12))
+            .vatIndicator(vatIndicator)
+            .netDisbursementAmount(100.11)
+            .disbursementVatAmount(22.22)
+            .caseConcludedDate(LocalDate.of(2025, 5, 12))
+            .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+            .feeCode("COM")
+            .feeScheme(FeeSchemesEntity.builder().schemeCode("COM_FS2013").build())
+            .fixedFee(new BigDecimal("50.00"))
+            .escapeThresholdLimit(escapeThreshold != null ? new BigDecimal(escapeThreshold) : null)
+            .categoryType(COMMUNITY_CARE)
+            .build();
+
+    FeeCalculationResponse result = familyFixedFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    ValidationMessagesInner validationMessage =
+            ValidationMessagesInner.builder()
+                    .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+                    .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+                    .type(WARNING)
+                    .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+    assertThat(result).isNotNull();
+    assertThat(result.getFeeCode()).isEqualTo("COM");
     assertThat(result.getFeeCalculation()).isNotNull();
     assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
   }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/ImmigrationAsylumFixedFeeCalculatorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.IMMIGRATION_ASYLUM;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.FIXED;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_400_LEGAL_HELP;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_600_CLR;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_ESCAPE_THRESHOLD;
@@ -245,6 +246,32 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
       assertThat(response.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "IACA, 100.0, 50.0, 600.0, 20.0, 50.0",
+        "IALB, 1000.0, 200.0, 400.0, 80.0, 200.0"
+    })
+    void calculate_capsDisbursementVatAtRateOfCappedNetDisbursement(String feeCode, double netDisbursementAmount,
+        double disbursementVatAmount, double disbursementLimit, double expectedDisbursementVat,
+        double expectedRequestedDisbursementVat) {
+
+      mockVatRatesService(true);
+
+      FeeCalculationRequest feeData = buildRequest(feeCode, netDisbursementAmount, disbursementVatAmount, true,
+          null, 0.0, 0.0);
+
+      FeeEntity feeEntity = buildFeeEntity(feeCode, BigDecimal.valueOf(75.5), BigDecimal.valueOf(disbursementLimit),
+          BigDecimal.valueOf(166), BigDecimal.valueOf(90), BigDecimal.valueOf(302));
+
+      FeeCalculationResponse response = immigrationAsylumFixedFeeCalculator.calculate(feeData, feeEntity);
+
+      assertThat(response.getFeeCalculation().getDisbursementVatAmount()).isEqualTo(expectedDisbursementVat);
+      assertThat(response.getFeeCalculation().getRequestedDisbursementVatAmount()).isEqualTo(expectedRequestedDisbursementVat);
+      assertThat(response.getValidationMessages())
+          .extracting(ValidationMessagesInner::getCode)
+          .contains(WARN_DISBURSEMENT_VAT_CAPPED.getCode());
+    }
+
   }
 
   @Nested
@@ -257,7 +284,6 @@ class ImmigrationAsylumFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .claimId("claim_123")
           .startDate(LocalDate.of(2025, 7, 29))
           .netDisbursementAmount(netDisbursementAmount)
-          .disbursementVatAmount(20.0)
           .vatIndicator(true)
           .immigrationPriorAuthorityNumber(null)
           .netProfitCosts(requestedNetProfitCosts)

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MediationFixedFeeCalculatorTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.MEDIATION;
 import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_MEDIATION_SESSIONS;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -19,11 +21,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.enums.WarningType;
 import uk.gov.justice.laa.fee.scheme.exception.ValidationException;
 import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class MediationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
@@ -33,22 +37,22 @@ class MediationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   public static Stream<Arguments> testData() {
     return Stream.of(
-        arguments("1 mediation session, VAT applied", "MDAS2B", true, 1, 130.65, null,
-            50.5, 20.15, 50, 10),
-        arguments("1 mediation session, no VAT", "MDAS2B", false, 1, 120.65, null,
-            50.5, 20.15, 50, 0),
-        arguments("2 mediation sessions, VAT applied", "MDAS2B", true, 2, 190.65, null,
-            50.5, 20.15, 100, 20),
-        arguments("2 mediation sessions, no VAT", "MDAS2B", false, 2, 170.65, null,
-            50.5, 20.15, 100, 0),
-        arguments("More than 1 mediation session, VAT applied", "MDAS2B", true, 3, 190.65, null,
-            50.5, 20.15, 100, 20),
-        arguments("More than 1 mediation session, no VAT", "MDAS2B", false, 3, 170.65, null,
-            50.5, 20.15, 100, 0),
-        arguments("No mediation sessions, VAT applied", "ASSA", true, null, 161.25, new BigDecimal("75.50"),
-            50.5, 20.15, 75.5, 15.1),
-        arguments("No mediation sessions, no VAT", "ASSA", false, null, 146.15, new BigDecimal("75.50"),
-            50.5, 20.15, 75.5, 0)
+        arguments("1 mediation session, VAT applied", "MDAS2B", true, 1, 120.6, null,
+            50.5, 10.1, 50, 10),
+        arguments("1 mediation session, no VAT", "MDAS2B", false, 1, 110.6, null,
+            50.5, 10.1, 50, 0),
+        arguments("2 mediation sessions, VAT applied", "MDAS2B", true, 2, 180.6, null,
+            50.5, 10.1, 100, 20),
+        arguments("2 mediation sessions, no VAT", "MDAS2B", false, 2, 160.6, null,
+            50.5, 10.1, 100, 0),
+        arguments("More than 1 mediation session, VAT applied", "MDAS2B", true, 3, 180.6, null,
+            50.5, 10.1, 100, 20),
+        arguments("More than 1 mediation session, no VAT", "MDAS2B", false, 3, 160.6, null,
+            50.5, 10.1, 100, 0),
+        arguments("No mediation sessions, VAT applied", "ASSA", true, null, 151.2, new BigDecimal("75.50"),
+            50.5, 10.1, 75.5, 15.1),
+        arguments("No mediation sessions, no VAT", "ASSA", false, null, 136.1, new BigDecimal("75.50"),
+            50.5, 10.1, 75.5, 0)
     );
   }
 
@@ -58,6 +62,28 @@ class MediationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     return Arguments.of(scenario, feeCode, vat, sessions, total, fixedFee, expectedDisbursementAmount, disbursementVatAmount,
         expectedFixedFee, expectedCalculatedVat);
   }
+
+  public static Stream<Arguments> disbursementTestData() {
+    return Stream.of(
+            arguments("1 mediation session, VAT applied", "MDAS2B", true, 1, 120.6, null,
+                    50.5, 10.1, 50, 10),
+            arguments("1 mediation session, no VAT", "MDAS2B", false, 1, 110.6, null,
+                    50.5, 10.1, 50, 0),
+            arguments("2 mediation sessions, VAT applied", "MDAS2B", true, 2, 180.6, null,
+                    50.5, 10.1, 100, 20),
+            arguments("2 mediation sessions, no VAT", "MDAS2B", false, 2, 160.6, null,
+                    50.5, 10.1, 100, 0),
+            arguments("More than 1 mediation session, VAT applied", "MDAS2B", true, 3, 180.6, null,
+                    50.5, 10.1, 100, 20),
+            arguments("More than 1 mediation session, no VAT", "MDAS2B", false, 3, 160.6, null,
+                    50.5, 10.1, 100, 0),
+            arguments("No mediation sessions, VAT applied", "ASSA", true, null, 151.2, new BigDecimal("75.50"),
+                    50.5, 10.1, 75.5, 15.1),
+            arguments("No mediation sessions, no VAT", "ASSA", false, null, 136.1, new BigDecimal("75.50"),
+                    50.5, 10.1, 75.5, 0)
+    );
+  }
+
 
   @ParameterizedTest
   @MethodSource("testData")
@@ -76,12 +102,17 @@ class MediationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
     mockVatRatesService(vatIndicator);
 
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
+
     FeeCalculationRequest feeData = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .claimId("claim_123")
         .startDate(LocalDate.of(2025, 7, 29))
         .netDisbursementAmount(50.50)
-        .disbursementVatAmount(20.15)
+        .disbursementVatAmount(10.1)
         .vatIndicator(vatIndicator)
         .numberOfMediationSessions(numberOfMediationSessions)
         .build();
@@ -148,6 +179,81 @@ class MediationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .isInstanceOf(ValidationException.class)
         .hasFieldOrPropertyWithValue("error", ERR_MEDIATION_SESSIONS)
         .hasMessage("ERRMED1 - Number of Mediation Sessions must be entered for the Fee Code used.");
+  }
+
+  @ParameterizedTest
+  @MethodSource("disbursementTestData")
+  void getFee_whenMediation_andDisbursementVatOverLimit(
+          String description,
+          String feeCode,
+          boolean vatIndicator,
+          Integer numberOfMediationSessions,
+          double expectedTotal,
+          BigDecimal fixedFee,
+          double expectedDisbursementAmount,
+          double disbursementVatAmount,
+          double expectedFixedFee,
+          double expectedCalculatedVat
+  ) {
+
+    mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
+    FeeCalculationRequest feeData = FeeCalculationRequest.builder()
+            .feeCode(feeCode)
+            .claimId("claim_123")
+            .startDate(LocalDate.of(2025, 7, 29))
+            .netDisbursementAmount(50.50)
+            .disbursementVatAmount(13.26)
+            .vatIndicator(vatIndicator)
+            .caseConcludedDate(LocalDate.of(2025, 7, 29))
+            .numberOfMediationSessions(numberOfMediationSessions)
+            .build();
+
+
+    FeeEntity feeEntity = FeeEntity.builder()
+            .feeCode(feeCode)
+            .feeScheme(FeeSchemesEntity.builder().schemeCode("MED_FS2013").build())
+            .fixedFee(fixedFee)
+            .mediationFeeLower(new BigDecimal("50"))
+            .mediationFeeHigher(new BigDecimal("100"))
+            .categoryType(MEDIATION)
+            .build();
+
+    FeeCalculationResponse response = mediationFeeCalculator.calculate(feeData, feeEntity);
+
+    ValidationMessagesInner validationMessage = ValidationMessagesInner.builder()
+            .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .type(WARNING)
+            .build();
+
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+            .totalAmount(expectedTotal)
+            .vatIndicator(vatIndicator)
+            .vatRateApplied(vatIndicator ? 20.0 : null)
+            .disbursementAmount(expectedDisbursementAmount)
+            .requestedNetDisbursementAmount(expectedDisbursementAmount)
+            .disbursementVatAmount(disbursementVatAmount)
+            .requestedDisbursementVatAmount(feeData.getDisbursementVatAmount())
+            .fixedFeeAmount(expectedFixedFee)
+            .calculatedVatAmount(expectedCalculatedVat)
+            .build();
+
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+            .feeCode(feeCode)
+            .schemeId("MED_FS2013")
+            .claimId("claim_123")
+            .feeCalculation(expectedCalculation)
+            .validationMessages(List.of(validationMessage))
+            .build();
+
+    assertThat(response)
+            .usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
   }
 
   @Test

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/MentalHealthFixedFeeCalculatorTest.java
@@ -59,8 +59,8 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .vatRateApplied(vatIndicator ? 20.0 : null)
         .disbursementAmount(50.50)
         .requestedNetDisbursementAmount(50.50)
-        .disbursementVatAmount(20.15)
-        .requestedDisbursementVatAmount(20.15)
+        .disbursementVatAmount(10.1)
+        .requestedDisbursementVatAmount(10.1)
         .fixedFeeAmount(fixedFee)
         .calculatedVatAmount(calculatedVat)
         .boltOnFeeDetails(BoltOnFeeDetails.builder()
@@ -89,12 +89,48 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .claimId("claim_123")
         .startDate(LocalDate.of(2025, 7, 29))
         .netDisbursementAmount(50.50)
-        .disbursementVatAmount(20.15)
+        .disbursementVatAmount(10.1)
         .vatIndicator(vatIndicator)
         .boltOns(BoltOnType.builder().boltOnAdjournedHearing(boltOnNumber).build())
         .netProfitCosts(requestedNetProfitCosts)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
+  }
+
+  private static FeeCalculationRequest buildFeeCalculationDisbursementVatLimitRequest(String feeCode, boolean vatIndicator,
+                                                                                      Integer boltOnNumber, Double requestedNetProfitCosts) {
+    return FeeCalculationRequest.builder()
+            .feeCode(feeCode)
+            .claimId("claim_123")
+            .startDate(LocalDate.of(2025, 7, 29))
+            .caseConcludedDate(LocalDate.of(2025, 7, 29))
+            .netDisbursementAmount(50.50)
+            .disbursementVatAmount(13.12)
+            .vatIndicator(vatIndicator)
+            .boltOns(BoltOnType.builder().boltOnAdjournedHearing(boltOnNumber).build())
+            .netProfitCosts(requestedNetProfitCosts)
+            .build();
+  }
+
+  private static FeeCalculation buildFeeCalculationDisbursementVatLimitReached(double fixedFee, boolean vatIndicator, Double calculatedVat,
+                                                                               Integer boltOnNumber, Double boltOnTotalFeeAmount,
+                                                                               Double boltOnAdjournedHearingFee, double expectedTotal) {
+    return FeeCalculation.builder()
+            .totalAmount(expectedTotal)
+            .vatIndicator(vatIndicator)
+            .vatRateApplied(vatIndicator ? 20.0 : null)
+            .disbursementAmount(50.50)
+            .requestedNetDisbursementAmount(50.50)
+            .disbursementVatAmount(10.1)
+            .requestedDisbursementVatAmount(13.12)
+            .fixedFeeAmount(fixedFee)
+            .calculatedVatAmount(calculatedVat)
+            .boltOnFeeDetails(BoltOnFeeDetails.builder()
+                    .boltOnTotalFeeAmount(boltOnTotalFeeAmount)
+                    .boltOnAdjournedHearingFee(boltOnAdjournedHearingFee)
+                    .boltOnAdjournedHearingCount(boltOnNumber)
+                    .build())
+            .build();
   }
 
   @Nested
@@ -103,16 +139,16 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     public static Stream<Arguments> testData() {
       return Stream.of(
           arguments("MHL01, with Vat, no bolt ons", "MHL01", 253.0, true, 50.6, null,
-              0.0, null, 374.25),
+              0.0, null, 364.2),
 
           arguments("MHL01, without vat, no bolt ons", "MHL01", 253.0, false, 0.0, null,
-              0.0, null, 323.65),
+              0.0, null, 313.6),
 
           arguments("MHL05, with Vat, has bolt ons", "MHL05", 263.0, true, 112.6, 3,
-              300.0, 300.0, 746.25),
+              300.0, 300.0, 736.2),
 
           arguments("MHL05, without vat, has bolt ons", "MHL05", 263.0, false, 0.0, 3,
-              300.0, 300.0, 633.65)
+              300.0, 300.0, 623.6)
       );
     }
 
@@ -140,6 +176,10 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
       mockVatRatesService(vatIndicator);
 
+      if (!vatIndicator) {
+        mockVatRatesVatIndicatorTrue();
+      }
+
       FeeCalculationRequest feeData = buildFeeCalculationRequest(feeCode, vatIndicator, boltOnNumber, null);
       FeeEntity feeEntity = buildFeeEntity(feeCode, fixedFee, null);
 
@@ -163,19 +203,19 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
       return Stream.of(
           argumentsEscapeCase("MHL01, with Vat, no bolt ons, escaped", "MHL01", 263.0,
               1000.0, true, 52.6, null,
-              0.0, null, 386.25, true, 759.0),
+              0.0, null, 376.2, true, 759.0),
 
           argumentsEscapeCase("MHL05, with Vat, has bolt ons, escaped", "MHL05", 321.0,
               1020.0, true, 124.2, 3,
-              300.0, 300.0, 815.85, true, 321.0),
+              300.0, 300.0, 805.8, true, 321.0),
 
           argumentsEscapeCase("MHL05, with Vat, has bolt ons, not escaped", "MHL05", 321.0,
               111.0, true, 124.2, 3,
-              300.0, 300.0, 815.85, false, 321.0),
+              300.0, 300.0, 805.8, false, 321.0),
 
           argumentsEscapeCase("MHL10, with Vat, has bolt ons, cannot escape", "MHL05", 129.0,
               1010.0, true, 85.8, 3,
-              300.0, 300.0, 585.45, false, null)
+              300.0, 300.0, 575.4, false, null)
       );
     }
 
@@ -232,8 +272,83 @@ class MentalHealthFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .usingRecursiveComparison()
           .isEqualTo(expectedResponse);
     }
+  }
+
+  @Nested
+  class MentalHealthDisbursementVatLimitTest {
+
+    public static Stream<Arguments> testDataVatLimit() {
+      return Stream.of(
+              argumentsVatLimit("MHL01, with Vat, no bolt ons", "MHL01", 253.0, true, 50.6, null,
+                      0.0, null, 364.2),
+
+              argumentsVatLimit("MHL01, without vat, no bolt ons", "MHL01", 253.0, false, 0.0, null,
+                      0.0, null, 313.6),
+
+              argumentsVatLimit("MHL05, with Vat, has bolt ons", "MHL05", 263.0, true, 112.6, 3,
+                      300.0, 300.0, 736.2),
+
+              argumentsVatLimit("MHL05, without vat, has bolt ons", "MHL05", 263.0, false, 0.0, 3,
+                      300.0, 300.0, 623.6)
+      );
+    }
+
+    private static Arguments argumentsVatLimit(String scenario, String feeCode, double fixedFee, boolean vat, Double calculatedVat,
+                                               Integer boltOnNumber, Double boltOnTotalFeeAmount, Double boltOnAdjournedHearingFee,
+                                               double expectedTotal) {
+
+      return Arguments.of(scenario, feeCode, fixedFee, vat, calculatedVat, boltOnNumber, boltOnTotalFeeAmount,
+              boltOnAdjournedHearingFee, expectedTotal);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDataVatLimit")
+    void getFee_whenMentalHealth_AndDisbursementVatLimit(
+            String description,
+            String feeCode,
+            double fixedFee,
+            boolean vatIndicator,
+            Double calculatedVat,
+            Integer boltOnNumber,
+            Double boltOnTotalFeeAmount,
+            Double boltOnAdjournedHearingFee,
+            double expectedTotal
+    ) {
+
+      mockVatRatesService(vatIndicator);
+
+      if (!vatIndicator) {
+        mockVatRatesVatIndicatorTrue();
+      }
+
+      FeeCalculationRequest feeData = buildFeeCalculationDisbursementVatLimitRequest(
+              feeCode, vatIndicator, boltOnNumber, null);
+      FeeEntity feeEntity = buildFeeEntity(feeCode, fixedFee, null);
+
+      FeeCalculationResponse response = mentalhealthFixedFeeCalculator.calculate(feeData, feeEntity);
+
+      List<ValidationMessagesInner> validationMessages = new ArrayList<>();
+      boolean hasEscaped = false;
+
+      ValidationMessagesInner validationMessage = ValidationMessagesInner.builder()
+              .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+              .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+              .type(WARNING)
+              .build();
+      validationMessages.add(validationMessage);
+
+
+      FeeCalculation expectedCalculation = buildFeeCalculationDisbursementVatLimitReached(fixedFee, vatIndicator, calculatedVat, boltOnNumber,
+              boltOnTotalFeeAmount, boltOnAdjournedHearingFee, expectedTotal);
+      FeeCalculationResponse expectedResponse = buildExpectedResponse(feeCode, expectedCalculation, hasEscaped, validationMessages);
+
+      assertThat(response)
+              .usingRecursiveComparison()
+              .isEqualTo(expectedResponse);
+    }
 
   }
+
 
   @Test
   void getSupportedCategories_shouldReturnEmptySet() {

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/OtherCivilFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/OtherCivilFixedFeeCalculatorTest.java
@@ -42,15 +42,19 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource({
-      "false, 200.00, 370.33, 0",  // Under escape threshold (No VAT)
-      "true, 200.00, 420.33, 50",  // Under escape threshold limit (VAT applied)
-      "false, 500.00, 370.33, 0", // Equal to escape threshold limit (No VAT)
-      "true, 500.00, 420.33, 50" // Equal to escape threshold limit (VAT applied)
+      "false, 200.00, 370.13, 0",  // Under escape threshold (No VAT)
+      "true, 200.00, 420.13, 50",  // Under escape threshold limit (VAT applied)
+      "false, 500.00, 370.13, 0", // Equal to escape threshold limit (No VAT)
+      "true, 500.00, 420.13, 50" // Equal to escape threshold limit (VAT applied)
   })
   void calculate_shouldReturnFeeCalculationResponse(boolean vatIndicator, double netProfitCosts,
                                                     double expectedTotal, double expectedVat) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netProfitCosts);
     FeeEntity feeEntity = buildFeeEntity();
@@ -62,13 +66,17 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource({
-      "false, 501.00, 370.33, 0", // Over escape threshold limit (No VAT)
-      "true, 501.00, 420.33, 50" // Over escape threshold limit (VAT applied)
+      "false, 501.00, 370.13, 0", // Over escape threshold limit (No VAT)
+      "true, 501.00, 420.13, 50" // Over escape threshold limit (VAT applied)
   })
   void calculate_shouldReturnFeeCalculationResponseWithWarning(boolean vatIndicator, double netProfitCosts,
                                                                double expectedTotal, double expectedVat) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netProfitCosts);
     FeeEntity feeEntity = buildFeeEntity();
@@ -84,6 +92,38 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .code(warningTypes.getFirst().getCode())
         .type(WARNING)
         .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "false, 200.00, 370.13, 0",  // Under escape threshold (No VAT)
+    "true, 200.00, 420.13, 50",  // Under escape threshold limit (VAT applied)
+    "false, 500.00, 370.13, 0", // Equal to escape threshold limit (No VAT)
+    "true, 500.00, 420.13, 50" // Equal to escape threshold limit (VAT applied)
+  })
+  void calculate_shouldReturnFeeCalculationResponseWithWarningOnDisbursementVAT(boolean vatIndicator, double netProfitCosts,
+                                                                                double expectedTotal, double expectedVat) {
+    mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
+    FeeCalculationRequest feeCalculationRequest = buildRequestDisbursementVatOverLimit(vatIndicator, netProfitCosts);
+    FeeEntity feeEntity = buildFeeEntity();
+
+    FeeCalculationResponse result = feeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertFeeCalculationDisbursementVatOverLimit(result, expectedTotal, vatIndicator, expectedVat, false);
+
+    ValidationMessagesInner validationMessage =
+            ValidationMessagesInner.builder()
+                    .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+                    .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+                    .type(WARNING)
+                    .build();
 
     assertThat(result.getValidationMessages()).containsExactly(validationMessage);
   }
@@ -134,7 +174,7 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .vatIndicator(vatIndicator)
         .netProfitCosts(netProfitCosts)
         .netDisbursementAmount(100.11)
-        .disbursementVatAmount(20.22)
+        .disbursementVatAmount(20.02)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
   }
@@ -165,7 +205,40 @@ class OtherCivilFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(vat);
     assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
     assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
-    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.22);
+    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.02);
+    assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(250);
+  }
+
+  private FeeCalculationRequest buildRequestDisbursementVatOverLimit(boolean vatIndicator, double netProfitCosts) {
+    return FeeCalculationRequest.builder()
+            .feeCode("CAPA")
+            .claimId("claim_123")
+            .startDate(LocalDate.of(2025, 4, 5))
+            .caseConcludedDate(LocalDate.of(2025, 5, 12))
+            .vatIndicator(vatIndicator)
+            .netProfitCosts(netProfitCosts)
+            .netDisbursementAmount(100.11)
+            .disbursementVatAmount(22.02)
+            .build();
+  }
+
+  private void assertFeeCalculationDisbursementVatOverLimit(FeeCalculationResponse response, double total, boolean vatIndicator, double vat,
+                                                            boolean escapeFlag) {
+    assertThat(response).isNotNull();
+    assertThat(response.getFeeCode()).isEqualTo("CAPA");
+    assertThat(response.getClaimId()).isEqualTo("claim_123");
+    assertThat(response.getSchemeId()).isEqualTo("CAPA_FS2013");
+    assertThat(response.getEscapeCaseFlag()).isEqualTo(escapeFlag);
+
+    FeeCalculation feeCalculation = response.getFeeCalculation();
+    assertThat(feeCalculation).isNotNull();
+    assertThat(feeCalculation.getTotalAmount()).isEqualTo(total);
+    assertThat(feeCalculation.getVatIndicator()).isEqualTo(vatIndicator);
+    assertThat(feeCalculation.getVatRateApplied()).isEqualTo(vatIndicator ? 20.0 : null);
+    assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(vat);
+    assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
+    assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
+    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.02);
     assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(250);
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PoliceStationFixedFeeCalculatorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.POLICE_STATION;
 import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_POLICE_SCHEME_ID;
 import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_POLICE_STATION_ID;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
@@ -67,7 +68,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .policeStationSchemeId("1001")
         .policeStationId("NE001")
         .netDisbursementAmount(50.50)
-        .disbursementVatAmount(20.15)
+        .disbursementVatAmount(10.10)
         .uniqueFileNumber("121222/452")
         .netProfitCosts(676.0)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
@@ -79,14 +80,14 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     FeeCalculationResponse response = policeStationFixedFeeCalculator.calculate(feeData, feeEntity);
 
     FeeCalculation expectedCalculation = FeeCalculation.builder()
-        .totalAmount(311.32)
+        .totalAmount(301.27)
         .vatIndicator(Boolean.TRUE)
         .vatRateApplied(20.0)
         .calculatedVatAmount(40.11)
         .disbursementAmount(50.5)
         .requestedNetDisbursementAmount(50.5)
-        .disbursementVatAmount(20.15)
-        .requestedDisbursementVatAmount(20.15)
+        .disbursementVatAmount(10.10)
+        .requestedDisbursementVatAmount(10.10)
         .fixedFeeAmount(200.56)
         .build();
 
@@ -122,7 +123,7 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .policeStationSchemeId("1001")
         .policeStationId(null)
         .netDisbursementAmount(50.50)
-        .disbursementVatAmount(20.15)
+        .disbursementVatAmount(10.10)
         .uniqueFileNumber("121222/452")
         .netProfitCosts(676.0)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
@@ -134,14 +135,14 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     FeeCalculationResponse response = policeStationFixedFeeCalculator.calculate(feeData, feeEntity);
 
     FeeCalculation expectedCalculation = FeeCalculation.builder()
-        .totalAmount(311.32)
+        .totalAmount(301.27)
         .vatIndicator(Boolean.TRUE)
         .vatRateApplied(20.0)
         .calculatedVatAmount(40.11)
         .disbursementAmount(50.5)
         .requestedNetDisbursementAmount(50.5)
-        .disbursementVatAmount(20.15)
-        .requestedDisbursementVatAmount(20.15)
+        .disbursementVatAmount(10.10)
+        .requestedDisbursementVatAmount(10.10)
         .fixedFeeAmount(200.56)
         .build();
 
@@ -173,7 +174,8 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
       double expectedCalculatedVat,
       double expectedDisbursementAmount,
       double disbursementVatAmount,
-      double expectedFixedFee
+      double expectedFixedFee,
+      boolean hasDisbVatWarning
   ) {
 
     mockVatRatesService(vatIndicator);
@@ -212,16 +214,25 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementAmount(expectedDisbursementAmount)
         .requestedNetDisbursementAmount(50.5)
         .disbursementVatAmount(disbursementVatAmount)
-        .requestedDisbursementVatAmount(disbursementVatAmount)
+        .requestedDisbursementVatAmount(20.15)
         .fixedFeeAmount(expectedFixedFee)
         .calculatedVatAmount(expectedCalculatedVat)
         .build();
+
+    List<ValidationMessagesInner> expectedMessages = new ArrayList<>();
+    if (hasDisbVatWarning) {
+      expectedMessages.add(ValidationMessagesInner.builder()
+          .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+          .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+          .type(WARNING)
+          .build());
+    }
 
     FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
         .feeCode(feeCode)
         .claimId("claim_123")
         .schemeId(feeSchemeCode)
-        .validationMessages(new ArrayList<>())
+        .validationMessages(expectedMessages)
         .escapeCaseFlag(false)
         .feeCalculation(expectedCalculation)
         .build();
@@ -482,13 +493,15 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   public static Stream<Arguments> testPoliceStationAttendanceClaims() {
     return Stream.of(
-        arguments("INVC Police Fee Code, VAT applied", "INVC", "NE001",
-            "1001", "121221/7899", true, 87.93,
-            new BigDecimal("14.4"), "POL_2016", 2.88, 14.4),
+        // vatIndicator=true: disbVat 20.15 > maxDisbVat (20% of 50.5 = 10.10) → capped, WARALL1 added
+        attendanceArguments("INVC Police Fee Code, VAT applied", "INVC", "NE001",
+            "1001", "121221/7899", true, 77.88,
+            new BigDecimal("14.4"), "POL_2016", 2.88, 14.4, true),
 
-        arguments("INVC Police Fee Code, VAT not applied", "INVC", "NE013",
-            "1004", "121223/6655", false, 85.05,
-            new BigDecimal("14.4"), "POL_2023", 0, 14.4)
+        // vatIndicator=false: disbVat 20.15 > maxDisbVat (20% of 50.5 = 10.10) → capped, WARALL1 added
+        attendanceArguments("INVC Police Fee Code, VAT not applied", "INVC", "NE013",
+            "1004", "121223/6655", false, 75.0,
+            new BigDecimal("14.4"), "POL_2023", 0, 14.4, true)
     );
   }
 
@@ -523,6 +536,24 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     );
   }
 
+  private static Arguments attendanceArguments(String testDescription,
+                                              String feeCode,
+                                              String policeStationId,
+                                              String policeStationSchemeId,
+                                              String uniqueFileNumber,
+                                              boolean vatIndicator,
+                                              double expectedTotal,
+                                              BigDecimal fixedFee,
+                                              String feeSchemeCode,
+                                              double expectedCalculatedVat,
+                                              double fixedFeeAmount,
+                                              boolean hasDisbVatWarning) {
+    // disbVat 20.15 always gets capped to 10.10 (20% of 50.5), regardless of vatIndicator
+    double expectedDisbVat = 10.10;
+    return Arguments.of(testDescription, feeCode, policeStationId, policeStationSchemeId, uniqueFileNumber, vatIndicator,
+        expectedTotal, fixedFee, feeSchemeCode, expectedCalculatedVat, 50.5, expectedDisbVat, fixedFeeAmount, hasDisbVatWarning);
+  }
+
   private static Arguments arguments(String testDescription,
                                      String feeCode,
                                      String policeStationId,
@@ -534,9 +565,11 @@ class PoliceStationFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
                                      String feeSchemeCode,
                                      double expectedCalculatedVat,
                                      double fixedFeeAmount) {
-
+    // When vatIndicator=true, disbVat 20.15 gets capped to 10.10 (20% of 50.5)
+    // When vatIndicator=false, vatRate=0 so cap is skipped and disbVat stays 20.15
+    double expectedDisbVat = vatIndicator ? 10.10 : 20.15;
     return Arguments.of(testDescription, feeCode, policeStationId, policeStationSchemeId, uniqueFileNumber, vatIndicator,
-        expectedTotal, fixedFee, feeSchemeCode, expectedCalculatedVat, 50.5, 20.15, fixedFeeAmount);
+        expectedTotal, fixedFee, feeSchemeCode, expectedCalculatedVat, 50.5, expectedDisbVat, fixedFeeAmount);
   }
 
   private FeeEntity buildFixedFeeEntity(String feeCode, FeeSchemesEntity feeSchemesEntity, BigDecimal fixedFee) {

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PrisonLawFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/PrisonLawFixedFeeCalculatorTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -295,5 +296,50 @@ class PrisonLawFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           .usingRecursiveComparison()
           .isEqualTo(expectedResponse);
     }
+  }
+
+
+
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "false, 500, 170.13", // No VAT
+      "true, 500, 180.13", // VAT applied
+      "true, null, 180.13" // No escape threshold limit
+  }, nullValues = "null")
+  void calculate_shouldReturnFeeCalculationResponse_withDisbursementLimitWarning(boolean vatIndicator, String escapeThreshold, double expectedTotal) {
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode("PRIC2")
+        .startDate(LocalDate.of(2025, 5, 12))
+        .vatIndicator(vatIndicator)
+        .netDisbursementAmount(100.11)
+        .disbursementVatAmount(22.22)
+        .caseConcludedDate(LocalDate.of(2025, 5, 12))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("PRIC2")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("PRISON_FS2016").build())
+        .fixedFee(new BigDecimal("50.00"))
+        .escapeThresholdLimit(escapeThreshold != null ? new BigDecimal(escapeThreshold) : null)
+        .categoryType(PRISON_LAW)
+        .build();
+
+    FeeCalculationResponse result = prisonLawFeeCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    ValidationMessagesInner validationMessage =
+        ValidationMessagesInner.builder()
+            .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .type(WARNING)
+            .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+    assertThat(result).isNotNull();
+    assertThat(result.getFeeCode()).isEqualTo("PRIC2");
+    assertThat(result.getFeeCalculation()).isNotNull();
+    assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/SendingHearingFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/SendingHearingFixedFeeCalculatorTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.fixed;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.SENDING_HEARING;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,11 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.entity.FeeSchemesEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
+import uk.gov.justice.laa.fee.scheme.enums.WarningType;
 import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.feecalculator.fixed.standard.SendingHearingFixedFeeCalculator;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class SendingHearingFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
@@ -29,8 +32,8 @@ class SendingHearingFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource({
-      "false, 270.33, 0",
-      "true, 300.33, 30.00"
+      "false, 270.13, 0",
+      "true, 300.13, 30.00"
   })
   void calculate_shouldReturnFeeCalculationResponse(boolean vatIndicator, double expectedTotal,
                                                     double expectedVat) {
@@ -43,7 +46,7 @@ class SendingHearingFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
         .representationOrderDate(LocalDate.of(2025, 1, 1))
         .vatIndicator(vatIndicator)
         .netDisbursementAmount(100.11)
-        .disbursementVatAmount(20.22)
+        .disbursementVatAmount(20.02)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
 
@@ -73,8 +76,52 @@ class SendingHearingFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
     assertThat(feeCalculation.getCalculatedVatAmount()).isEqualTo(vat);
     assertThat(feeCalculation.getDisbursementAmount()).isEqualTo(100.11);
     assertThat(feeCalculation.getRequestedNetDisbursementAmount()).isEqualTo(100.11);
-    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.22);
+    assertThat(feeCalculation.getDisbursementVatAmount()).isEqualTo(20.02);
     assertThat(feeCalculation.getFixedFeeAmount()).isEqualTo(150);
+  }
+
+
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "false, 500, 170.13", // No VAT
+      "true, 500, 180.13", // VAT applied
+      "true, null, 180.13" // No escape threshold limit
+  }, nullValues = "null")
+  void calculate_shouldReturnFeeCalculationResponse_withDisbursementLimitWarning(boolean vatIndicator, String escapeThreshold, double expectedTotal) {
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode("PROW")
+        .startDate(LocalDate.of(2025, 5, 12))
+        .vatIndicator(vatIndicator)
+        .netDisbursementAmount(100.11)
+        .disbursementVatAmount(22.22)
+        .caseConcludedDate(LocalDate.of(2025, 5, 12))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("PROW")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("SEND_HEAR_FS2022").build())
+        .fixedFee(new BigDecimal("50.00"))
+        .escapeThresholdLimit(escapeThreshold != null ? new BigDecimal(escapeThreshold) : null)
+        .categoryType(SENDING_HEARING)
+        .build();
+
+    FeeCalculationResponse result = calculator.calculate(feeCalculationRequest, feeEntity);
+
+    ValidationMessagesInner validationMessage =
+        ValidationMessagesInner.builder()
+            .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .type(WARNING)
+            .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+    assertThat(result).isNotNull();
+    assertThat(result.getFeeCode()).isEqualTo("PROW");
+    assertThat(result.getFeeCalculation()).isNotNull();
+    assertThat(result.getFeeCalculation().getTotalAmount()).isEqualTo(expectedTotal);
   }
 
   @Test

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/fixed/UndesignatedCourtFixedFeeCalculatorTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.MAGISTRATES_COURT;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.YOUTH_COURT;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.FIXED;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -25,6 +27,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class UndesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
@@ -188,6 +191,48 @@ class UndesignatedCourtFixedFeeCalculatorTest extends BaseFeeCalculatorTest {
           feeCalculationRequest, vatIndicator, expectedTotal, expectedVat, expectedNetTravel, expectedNetWaiting);
 
       assertThat(response).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void calculate_whenDisbursementVatExceedsCap_shouldReturnWarnDisbursementVatCapped() {
+
+      mockVatRatesService(true);
+
+      // disbursementVatAmount 30.00 > 20% of netDisbursementAmount 100.00 (max = 20.00)
+      FeeCalculationRequest request = FeeCalculationRequest.builder()
+          .feeCode("PROE1")
+          .claimId("claim_123")
+          .representationOrderDate(LocalDate.of(2025, 7, 29))
+          .netDisbursementAmount(100.00)
+          .disbursementVatAmount(30.00)
+          .vatIndicator(true)
+          .netTravelCosts(50.00)
+          .netWaitingCosts(60.00)
+          .caseConcludedDate(LocalDate.of(2026, 1, 30))
+          .build();
+
+      FeeEntity feeEntity = FeeEntity.builder()
+          .feeCode("PROE1")
+          .feeScheme(FeeSchemesEntity.builder().schemeCode("MAGS_COURT_FS2022").build())
+          .fixedFee(new BigDecimal("223.88"))
+          .categoryType(MAGISTRATES_COURT)
+          .courtDesignationType(CourtDesignationType.UNDESIGNATED)
+          .feeType(FIXED)
+          .build();
+
+      FeeCalculationResponse response = calculator.calculate(request, feeEntity);
+
+      // fixedFeeAndAdditional=333.88, vatOnFixed=66.78, netDisbAmt=100.00, cappedDisbVat=20.00 → total=520.66
+      assertThat(response.getFeeCalculation().getTotalAmount()).isEqualTo(520.66);
+      assertThat(response.getFeeCalculation().getDisbursementVatAmount()).isEqualTo(20.00);
+      assertThat(response.getFeeCalculation().getRequestedDisbursementVatAmount()).isEqualTo(30.00);
+      assertThat(response.getValidationMessages()).containsExactly(
+          ValidationMessagesInner.builder()
+              .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+              .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+              .type(WARNING)
+              .build()
+      );
     }
 
   }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdviceAssistanceAdvocacyHourlyRateCalculatorTest.java
@@ -3,9 +3,12 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.hourly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ADVICE_ASSISTANCE_ADVOCACY;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class AdviceAssistanceAdvocacyHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
@@ -40,8 +44,8 @@ class AdviceAssistanceAdvocacyHourlyRateCalculatorTest extends BaseFeeCalculator
     return Stream.of(
         arguments("PROD, with VAT", "PROD", true, 100.0, 20.0, 290,
             180, 120, 118.0, 590.0, 828.0),
-        arguments("PROD, without VAT", "PROD", false, 100.0, 20.0, 190,
-            110, 150, 0.0, 450.0, 570.0)
+        arguments("PROD, without VAT", "PROD", false, 100.0, 0.0, 190,
+            110, 150, 0.0, 450.0, 550.0)
     );
   }
 
@@ -99,7 +103,7 @@ class AdviceAssistanceAdvocacyHourlyRateCalculatorTest extends BaseFeeCalculator
         .calculatedVatAmount(calculatedVatAmount)
         .disbursementAmount(netDisbursementAmount)
         .requestedNetDisbursementAmount(netDisbursementAmount)
-        .disbursementVatAmount(disbursementVatAmount)
+        .disbursementVatAmount(vatIndicator ? disbursementVatAmount : null)
         .requestedDisbursementVatAmount(disbursementVatAmount)
         .hourlyTotalAmount(hourlyTotalAmount)
         .netProfitCostsAmount(requestedProfitCosts)
@@ -115,6 +119,174 @@ class AdviceAssistanceAdvocacyHourlyRateCalculatorTest extends BaseFeeCalculator
         .schemeId("AAA_FS2016")
         .claimId("claim_123")
         .validationMessages(new ArrayList<>())
+        .feeCalculation(expectedCalculation)
+        .build();
+
+    assertThat(response)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedResponse);
+  }
+
+  public static Stream<Arguments> testDataForDisbursementWithoutVat() {
+    return Stream.of(
+        // scenario, feeCode, vatIndicator, netDisbAmt, submittedDisbVat, expectedDisbVat, hasDisbVatWarning,
+        //   profitCosts, travelCosts, waitingCosts, calcVat, hourlyTotal, expectedTotal
+        Arguments.of("PROD, without VAT", "PROD", false, 100.0, 20.0, 20.0, true,
+            190.0, 110.0, 150.0, 0.0, 450.0, 570.0)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testDataForDisbursementWithoutVat")
+  void calculate_whenAdviceAssistanceAdvocacyClaimHasHigherDisbursementVatAmountWithoutVat(
+      String description,
+      String feeCode,
+      boolean vatIndicator,
+      double netDisbursementAmount,
+      double disbursementVatAmount,
+      Double expectedDisbVatAmount,
+      boolean hasDisbVatWarning,
+      double requestedProfitCosts,
+      double requestedTravelCosts,
+      double requestedWaitingCosts,
+      double calculatedVatAmount,
+      double hourlyTotalAmount,
+      double expectedTotal
+  ) {
+
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode(feeCode)
+        .claimId("claim_123")
+        .caseConcludedDate(LocalDate.of(2024, 7, 29))
+        .netProfitCosts(requestedProfitCosts)
+        .netDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(disbursementVatAmount)
+        .vatIndicator(vatIndicator)
+        .netTravelCosts(requestedTravelCosts)
+        .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode(feeCode)
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("AAA_FS2016").build())
+        .categoryType(ADVICE_ASSISTANCE_ADVOCACY)
+        .feeType(HOURLY)
+        .build();
+
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+        .totalAmount(expectedTotal)
+        .vatIndicator(vatIndicator)
+        .vatRateApplied(vatIndicator ? 20.0 : null)
+        .calculatedVatAmount(calculatedVatAmount)
+        .disbursementAmount(netDisbursementAmount)
+        .requestedNetDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(expectedDisbVatAmount)      // capped value
+        .requestedDisbursementVatAmount(disbursementVatAmount) // original submitted
+        .hourlyTotalAmount(hourlyTotalAmount)
+        .netProfitCostsAmount(requestedProfitCosts)
+        .requestedNetProfitCostsAmount(requestedProfitCosts)
+        .netTravelCostsAmount(requestedTravelCosts)
+        .netWaitingCostsAmount(requestedWaitingCosts)
+        .build();
+
+    List<ValidationMessagesInner> expectedMessages = new ArrayList<>();
+
+    FeeCalculationResponse response = adviceAssistanceAdvocacyHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+        .feeCode(feeCode)
+        .schemeId("AAA_FS2016")
+        .claimId("claim_123")
+        .validationMessages(expectedMessages)
+        .feeCalculation(expectedCalculation)
+        .build();
+
+    assertThat(response)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedResponse);
+  }
+
+  public static Stream<Arguments> testDataForDisbursementWithVat() {
+    return Stream.of(
+        // scenario, feeCode, vatIndicator, netDisbAmt, submittedDisbVat, expectedDisbVat, hasDisbVatWarning,
+        //   profitCosts, travelCosts, waitingCosts, calcVat, hourlyTotal, expectedTotal
+        Arguments.of("PROD, with VAT", "PROD", true, 100.0, 26.0, 20.0, true,
+            290.0, 180.0, 120.0, 118.0, 590.0, 828.0)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testDataForDisbursementWithVat")
+  void calculate_whenAdviceAssistanceAdvocacyClaimHasHigherDisbursementVatAmountAndVatIsApplied(
+      String description,
+      String feeCode,
+      boolean vatIndicator,
+      double netDisbursementAmount,
+      double disbursementVatAmount,
+      Double expectedDisbVatAmount,
+      boolean hasDisbVatWarning,
+      double requestedProfitCosts,
+      double requestedTravelCosts,
+      double requestedWaitingCosts,
+      double calculatedVatAmount,
+      double hourlyTotalAmount,
+      double expectedTotal
+  ) {
+
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode(feeCode)
+        .claimId("claim_123")
+        .caseConcludedDate(LocalDate.of(2024, 7, 29))
+        .netProfitCosts(requestedProfitCosts)
+        .netDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(disbursementVatAmount)
+        .vatIndicator(vatIndicator)
+        .netTravelCosts(requestedTravelCosts)
+        .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode(feeCode)
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("AAA_FS2016").build())
+        .categoryType(ADVICE_ASSISTANCE_ADVOCACY)
+        .feeType(HOURLY)
+        .build();
+
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+        .totalAmount(expectedTotal)
+        .vatIndicator(vatIndicator)
+        .vatRateApplied(vatIndicator ? 20.0 : null)
+        .calculatedVatAmount(calculatedVatAmount)
+        .disbursementAmount(netDisbursementAmount)
+        .requestedNetDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(expectedDisbVatAmount)      // capped value
+        .requestedDisbursementVatAmount(disbursementVatAmount) // original submitted
+        .hourlyTotalAmount(hourlyTotalAmount)
+        .netProfitCostsAmount(requestedProfitCosts)
+        .requestedNetProfitCostsAmount(requestedProfitCosts)
+        .netTravelCostsAmount(requestedTravelCosts)
+        .netWaitingCostsAmount(requestedWaitingCosts)
+        .build();
+
+    List<ValidationMessagesInner> expectedMessages = hasDisbVatWarning
+        ? List.of(ValidationMessagesInner.builder()
+                  .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+                  .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+                  .type(WARNING)
+                  .build())
+        : new ArrayList<>();
+
+    FeeCalculationResponse response = adviceAssistanceAdvocacyHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+        .feeCode(feeCode)
+        .schemeId("AAA_FS2016")
+        .claimId("claim_123")
+        .validationMessages(expectedMessages)
         .feeCalculation(expectedCalculation)
         .build();
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/AdvocacyAppealsReviewsHourlyRateCalculatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.ADVOCACY_APPEALS_REVIEWS;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_ADVOCACY_APPEALS_REVIEWS_UPPER_LIMIT;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
@@ -54,12 +55,8 @@ class AdvocacyAppealsReviewsHourlyRateCalculatorTest extends BaseFeeCalculatorTe
         arguments("APPA, no VAT, no warning", "APPA", false, 40, 5, 100,
             50, 50, 314.81, 0, 200, 245, false),
         arguments("APPB, no VAT, no warning", "APPB", false, 50, 10, 210,
-            50, 50, 524, 0, 310, 370, false),
-        arguments("PROH, with VAT, has warning", "PROH", true, 100, 20, 1200,
-            100, 200, 1574.06, 300, 1500, 1920, true),
-        arguments("APPA, no VAT, has warning", "APPA", false, 40, 5, 200,
-            50, 50, 314.81, 0, 300, 345, true)
-    );
+            50, 50, 524, 0, 310, 370, false)
+);
   }
 
   private static Arguments arguments(String scenario, String feeCode, boolean vat,
@@ -74,6 +71,94 @@ class AdvocacyAppealsReviewsHourlyRateCalculatorTest extends BaseFeeCalculatorTe
   @ParameterizedTest
   @MethodSource("testData")
   void calculate_whenAdvocacyAppealsReviews(
+      String description,
+      String feeCode,
+      boolean vatIndicator,
+      double netDisbursementAmount,
+      double disbursementVatAmount,
+      double requestedProfitCosts,
+      double requestedTravelCosts,
+      double requestedWaitingCosts,
+      double upperCostLimit,
+      double calculatedVatAmount,
+      double hourlyTotalAmount,
+      double expectedTotal,
+      boolean hasWarning
+  ) {
+
+    mockVatRatesService(vatIndicator);
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+        .feeCode(feeCode)
+        .claimId("claim_123")
+        .uniqueFileNumber("110425/123")
+        .netProfitCosts(requestedProfitCosts)
+        .netDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(disbursementVatAmount)
+        .vatIndicator(vatIndicator)
+        .netTravelCosts(requestedTravelCosts)
+        .netWaitingCosts(requestedWaitingCosts)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode(feeCode)
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("AAR_FS2022").build())
+        .categoryType(ADVOCACY_APPEALS_REVIEWS)
+        .feeType(HOURLY)
+        .upperCostLimit(BigDecimal.valueOf(upperCostLimit))
+        .build();
+
+    FeeCalculationResponse response = calculator.calculate(feeCalculationRequest, feeEntity);
+
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+        .totalAmount(expectedTotal)
+        .vatIndicator(vatIndicator)
+        .vatRateApplied(vatIndicator ? 20.0 : null)
+        .calculatedVatAmount(calculatedVatAmount)
+        .disbursementAmount(netDisbursementAmount)
+        .requestedNetDisbursementAmount(netDisbursementAmount)
+        .disbursementVatAmount(disbursementVatAmount)
+        .requestedDisbursementVatAmount(disbursementVatAmount)
+        .hourlyTotalAmount(hourlyTotalAmount)
+        .netProfitCostsAmount(requestedProfitCosts)
+        .requestedNetProfitCostsAmount(requestedProfitCosts)
+        .netTravelCostsAmount(requestedTravelCosts)
+        .netWaitingCostsAmount(requestedWaitingCosts)
+        .build();
+
+    List<ValidationMessagesInner> validationMessages = List.of(
+        ValidationMessagesInner.builder()
+            .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .type(WARNING)
+            .build());
+
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+        .feeCode(feeCode)
+        .schemeId("AAR_FS2022")
+        .claimId("claim_123")
+        .validationMessages(hasWarning ? validationMessages : new ArrayList<>())
+        .feeCalculation(expectedCalculation)
+        .build();
+
+    assertThat(response)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedResponse);
+  }
+
+  public static Stream<Arguments> testDataForUpperCostLimits() {
+    return Stream.of(
+        arguments("PROH, with VAT, has warning", "PROH", true, 100, 20, 1200,
+            100, 200, 1574.06, 300, 1500, 1920, true),
+        arguments("APPA, no VAT, has warning", "APPA", false, 40, 5, 200,
+            50, 50, 314.81, 0, 300, 345, true)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testDataForUpperCostLimits")
+  void calculate_whenAdvocacyAppealsReviewClaimAmountExceedsUpperCostLimit(
       String description,
       String feeCode,
       boolean vatIndicator,

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/DiscriminationHourlyRateCalculatorTest.java
@@ -31,8 +31,8 @@ class DiscriminationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
 
   @ParameterizedTest
   @CsvSource({
-      "false, 149.50, 300.50, 528.24, 0, 450.00",  // Under escape threshold (No VAT)
-      "true, 149.50, 300.50, 618.24, 90.00, 450.00",  // Under escape threshold limit (VAT applied)
+      "false, 149.50, 300.50, 528.24, 0, 450.00", // Under escape threshold (No VAT)
+      "true, 149.50, 300.50, 618.24, 90.00, 450.00", // Under escape threshold limit (VAT applied)
       "false, 199.50, 500.50, 778.24, 0, 700.00", // Equal to escape threshold limit (No VAT)
       "true, 199.50, 500.50, 918.24, 140.00, 700.00" // Equal to escape threshold limit (VAT applied)
   })
@@ -40,6 +40,10 @@ class DiscriminationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                     double expectedTotal, double expectedVat, double expectedHourlyTotal) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netProfitCosts, costOfCounsel);
     FeeEntity feeEntity = buildFeeEntity();
@@ -55,13 +59,17 @@ class DiscriminationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   @ParameterizedTest
   @CsvSource({
       "false, 300.50, 500.50, 778.24, 0, 700.00", // Over escape threshold limit (No VAT)
-      "true, 300.50, 500.50, 918.24, 140.00, 700.00"  // Over escape threshold limit (VAT applied)
+      "true, 300.50, 500.50, 918.24, 140.00, 700.00" // Over escape threshold limit (VAT applied)
   })
   void calculate_shouldReturnFeeCalculationResponseWithWarning(boolean vatIndicator, double netProfitCosts,
                                                                double costOfCounsel, double expectedTotal,
                                                                double expectedVat, double expectedHourlyTotal) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = buildRequest(vatIndicator, netProfitCosts, costOfCounsel);
     FeeEntity feeEntity = buildFeeEntity();
@@ -100,6 +108,68 @@ class DiscriminationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .disbursementVatAmount(13.04)
         .caseConcludedDate(LocalDate.of(2026, 1, 30))
         .build();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "false, 149.50, 300.50, 528.24, 0, 450.00", // Under escape threshold (No VAT)
+    "true, 149.50, 300.50, 618.24, 90.00, 450.00", // Under escape threshold limit (VAT applied)
+    "false, 199.50, 500.50, 778.24, 0, 700.00", // Equal to escape threshold limit (No VAT)
+    "true, 199.50, 500.50, 918.24, 140.00, 700.00" // Equal to escape threshold limit (VAT applied)
+  })
+  void calculate_shouldReturnFeeCalculationResponseWithDisbursementVatWarning(
+          boolean vatIndicator,
+          double netProfitCosts,
+          double costOfCounsel,
+          double expectedTotal,
+          double expectedVat,
+          double expectedHourlyTotal) {
+    mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
+    FeeCalculationRequest feeCalculationRequest =
+            buildRequestDisbursementVatLimit(vatIndicator, netProfitCosts, costOfCounsel);
+    FeeEntity feeEntity = buildFeeEntity();
+
+    FeeCalculationResponse result =
+            discriminationHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertFeeCalculation(
+            result,
+            expectedTotal,
+            vatIndicator,
+            netProfitCosts,
+            costOfCounsel,
+            expectedVat,
+            expectedHourlyTotal,
+            false);
+
+    ValidationMessagesInner validationMessage =
+            ValidationMessagesInner.builder()
+                    .message(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+                    .code(WarningType.WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+                    .type(WARNING)
+                    .build();
+
+    assertThat(result.getValidationMessages()).containsExactly(validationMessage);
+  }
+
+  private FeeCalculationRequest buildRequestDisbursementVatLimit(
+          boolean vatIndicator, double netProfitCosts, double costOfCounsel) {
+    return FeeCalculationRequest.builder()
+            .feeCode("DISC")
+            .claimId("claim_123")
+            .startDate(LocalDate.of(2025, 5, 12))
+            .caseConcludedDate(LocalDate.of(2025, 5, 12))
+            .netProfitCosts(netProfitCosts)
+            .netCostOfCounsel(costOfCounsel)
+            .vatIndicator(vatIndicator)
+            .netDisbursementAmount(65.20)
+            .disbursementVatAmount(14.04)
+            .build();
   }
 
   private FeeEntity buildFeeEntity() {

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
@@ -2,8 +2,10 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.hourly;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.IMMIGRATION_ASYLUM;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DETENTION_TRAVEL;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_LEGAL_HELP;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_JR_FORM_FILLING;
@@ -57,6 +59,10 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                      double expectedNetDisbursement, List<WarningType> expectedWarnings) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest
         feeCalculationRequest = FeeCalculationRequest.builder()
@@ -165,6 +171,10 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
 
     mockVatRatesService(vatIndicator);
 
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
@@ -227,13 +237,14 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                                     Double jrFormFilling,
                                                                                     List<WarningType> expectedWarnings) {
     mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode("IAXL")
         .startDate(LocalDate.of(2025, 5, 11))
         .netProfitCosts(166.25)
         .netDisbursementAmount(123.38)
-        .disbursementVatAmount(24.67)
+        .disbursementVatAmount(20.67)
         .detentionTravelAndWaitingCosts(detentionTravelAndWaitingCosts)
         .jrFormFilling(jrFormFilling)
         .vatIndicator(false)
@@ -258,6 +269,94 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   }
 
   @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenLegalHelpDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IAXL")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IAXL");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenClrDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IAXC")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IAXC");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenClrInterimDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IMCD")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IMCD");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  static Stream<Arguments> disbursementVatWarningTestData() {
+    return Stream.of(
+            // Legal Help
+            Arguments.of(314.37, 314.31, List.of(WARN_DISBURSEMENT_VAT_CAPPED)),
+            Arguments.of(1000.10, 314.31,  List.of(WARN_DISBURSEMENT_VAT_CAPPED)),
+            Arguments.of(200.46, 314.31, List.of(WARN_DISBURSEMENT_VAT_CAPPED))
+    );
+  }
+
+
+  @ParameterizedTest
   @MethodSource("feeTestDataClr")
   void calculateFee_whenClr_shouldReturnFeeCalculationResponse(String feeCode, boolean vatIndicator, String priorAuthority,
                                                                double netProfitCosts, double netCostOfCounsel, double netDisbursement,
@@ -266,9 +365,14 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
 
     mockVatRatesService(vatIndicator);
 
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(netProfitCosts)
         .netCostOfCounsel(netCostOfCounsel)
         .netDisbursementAmount(netDisbursement)
@@ -333,10 +437,13 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                        Double jrFormFilling, List<WarningType> expectedWarnings) {
 
     mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(486.78)
         .netCostOfCounsel(611.25)
         .netDisbursementAmount(152.34)
@@ -380,9 +487,15 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                       List<WarningType> expectedWarnings) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(netProfitCosts)
         .netCostOfCounsel(netCostOfCounsel)
         .boltOns(requestedBoltOns)
@@ -422,34 +535,34 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   static Stream<Arguments> feeTestDataClrInterim() {
     return Stream.of(
         // under total limit
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2054.83, 0, 2024.37, List.of()),
-        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2429.24, 374.41, 2024.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2034.83, 0, 2024.37, List.of()),
+        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2409.24, 374.41, 2024.37, List.of()),
 
         // over total "with" prior authority
-        Arguments.of("IACD", NO_VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2451.75, 0, 2421.29, List.of()),
-        Arguments.of("IACD", VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2905.54, 453.79, 2421.29, List.of()),
+        Arguments.of("IACD", NO_VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2431.75, 0, 2421.29, List.of()),
+        Arguments.of("IACD", VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2885.54, 453.79, 2421.29, List.of()),
 
         // over total limit "without" prior authority
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2404.46, 0, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
-        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2858.25, 453.79, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2384.46, 0, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
+        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2838.25, 453.79, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
 
         // substantive hearing bolt on = false
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(false), 486.78, 611.25, 152.34, 30.46,
-            1752.83, 0, 1722.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(false), 486.78, 611.25, 152.34, 10.46,
+            1732.83, 0, 1722.37, List.of()),
 
         // no bolt ons
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, null, 486.78, 611.25, 152.34, 30.46,
-            1280.83, 0, 1250.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, null, 486.78, 611.25, 152.34, 10.46,
+            1260.83, 0, 1250.37, List.of()),
 
         // IMCD
-        Arguments.of("IMCD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2054.83, 0, 2024.37, List.of())
+        Arguments.of("IMCD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2034.83, 0, 2024.37, List.of())
     );
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PoliceStationHourlyRateCalculatorTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.hourly;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.POLICE_STATION;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_POLICE_OTHER_UPPER_LIMIT;
 import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
@@ -286,10 +287,13 @@ class PoliceStationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .type(WARNING)
         .build();
 
+    List<ValidationMessagesInner> expectedMessages = new ArrayList<>();
+    expectedMessages.add(validationMessage);
+
     FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
         .feeCode(feeCode)
         .schemeId(feeSchemeCode)
-        .validationMessages(List.of(validationMessage))
+        .validationMessages(expectedMessages)
         .feeCalculation(expectedCalculation)
         .build();
 
@@ -298,6 +302,186 @@ class PoliceStationHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
         .isEqualTo(expectedResponse);
   }
 
+
+  @ParameterizedTest
+  @MethodSource("testPoliceOtherData")
+  void test_whenPoliceStation_shouldReturnFeeWithWarningForPoliceUpperLimit(
+      String description,
+      String feeCode,
+      boolean inputVatIndicator,
+      LocalDate startDate,
+      String feeSchemeCode,
+      double inputNetProfitCosts,
+      double inputDisbursementAmount,
+      double inputDisbursementVatAmount,
+      double inputNetTravelCosts,
+      double inputNetWaitingCosts,
+      double expectedTotal,
+      double expectedCalculatedVat,
+      double expectedHourlyTotalAmount
+  ) {
+
+    mockVatRatesService(inputVatIndicator);
+
+    FeeCalculationRequest feeData = FeeCalculationRequest.builder()
+        .feeCode(feeCode)
+        .startDate(startDate)
+        .vatIndicator(inputVatIndicator)
+        .netProfitCosts(inputNetProfitCosts)
+        .netDisbursementAmount(inputDisbursementAmount)
+        .disbursementVatAmount(inputDisbursementVatAmount)
+        .netTravelCosts(inputNetTravelCosts)
+        .netWaitingCosts(inputNetWaitingCosts)
+        .uniqueFileNumber(UFN)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode(feeSchemeCode).build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode(feeCode)
+        .feeScheme(feeSchemesEntity)
+        .upperCostLimit(new BigDecimal("25.0"))
+        .categoryType(POLICE_STATION)
+        .feeType(FeeType.HOURLY)
+        .build();
+
+    FeeCalculationResponse response = policeStationHourlyRateCalculator.calculate(feeData, feeEntity);
+
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+        .totalAmount(expectedTotal)
+        .vatIndicator(inputVatIndicator)
+        .vatRateApplied(inputVatIndicator ? 20.0 : null)
+        .disbursementAmount(inputDisbursementAmount)
+        .requestedNetDisbursementAmount(inputDisbursementAmount)
+        .disbursementVatAmount(inputDisbursementVatAmount)
+        .requestedDisbursementVatAmount(inputDisbursementVatAmount)
+        .calculatedVatAmount(expectedCalculatedVat)
+        .netProfitCostsAmount(inputNetProfitCosts)
+        .requestedNetProfitCostsAmount(inputNetProfitCosts)
+        .hourlyTotalAmount(expectedHourlyTotalAmount)
+        .netTravelCostsAmount(inputNetTravelCosts)
+        .netWaitingCostsAmount(inputNetWaitingCosts)
+        .build();
+    ValidationMessagesInner validationMessage = ValidationMessagesInner.builder()
+        .code(WARN_POLICE_OTHER_UPPER_LIMIT.getCode())
+        .message(WARN_POLICE_OTHER_UPPER_LIMIT.getMessage())
+        .type(WARNING)
+        .build();
+
+    List<ValidationMessagesInner> expectedMessages = new ArrayList<>();
+    expectedMessages.add(validationMessage);
+
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+        .feeCode(feeCode)
+        .schemeId(feeSchemeCode)
+        .validationMessages(expectedMessages)
+        .feeCalculation(expectedCalculation)
+        .build();
+
+    assertThat(response)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedResponse);
+  }
+
+
+  @Test
+  void test_whenPoliceStation_shouldReturnFeeWithWarningForCappedDisbursementVatAmount() {
+
+    mockVatRatesService(true);
+
+    FeeCalculationRequest feeData = FeeCalculationRequest.builder()
+        .feeCode("INVM")
+        .startDate(LocalDate.of(2025, 5, 20))
+        .vatIndicator(true)
+        .netProfitCosts(1432.38)
+        .netDisbursementAmount(123.38)
+        .disbursementVatAmount(24.67)
+        .netTravelCosts(45.64)
+        .uniqueFileNumber(UFN)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode("POL_FS2022").build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("INVM")
+        .feeScheme(feeSchemesEntity)
+        .upperCostLimit(new BigDecimal("1900.0"))
+        .categoryType(POLICE_STATION)
+        .feeType(FeeType.HOURLY)
+        .build();
+
+    FeeCalculationResponse response = policeStationHourlyRateCalculator.calculate(feeData, feeEntity);
+
+    assertThat(response.getFeeCode()).isEqualTo("INVM");
+    assertThat(response.getSchemeId()).isEqualTo("POL_FS2022");
+  }
+
+  @Test
+  void test_whenDisbursementVatExceedsCap_shouldReturnWarnDisbursementVatCapped() {
+
+    mockVatRatesService(true);
+
+    FeeCalculationRequest feeData = FeeCalculationRequest.builder()
+        .feeCode("INVA")
+        .startDate(LocalDate.of(2022, 5, 20))
+        .vatIndicator(true)
+        .netProfitCosts(500.0)
+        .netDisbursementAmount(100.0)
+        .disbursementVatAmount(30.0)  // exceeds 20% cap of 100.0 (max = 20.0)
+        .netTravelCosts(50.0)
+        .netWaitingCosts(0.0)
+        .uniqueFileNumber(UFN)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeSchemesEntity feeSchemesEntity = FeeSchemesEntity.builder().schemeCode("POL_FS2022").build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("INVA")
+        .feeScheme(feeSchemesEntity)
+        .upperCostLimit(new BigDecimal("10000.0"))
+        .categoryType(POLICE_STATION)
+        .feeType(FeeType.HOURLY)
+        .build();
+
+    FeeCalculationResponse response = policeStationHourlyRateCalculator.calculate(feeData, feeEntity);
+
+    // vatEligibleFeeTotal = 500 + 50 + 0 = 550; feeTotal = 550 + 100 = 650
+    // calculatedVat = 550 * 20% = 110.0; cappedDisbVat = min(30.0, 100*20%) = 20.0
+    // totalAmount = 650 + 110 + 20 = 780.0
+    FeeCalculation expectedCalculation = FeeCalculation.builder()
+        .totalAmount(780.0)
+        .vatIndicator(true)
+        .vatRateApplied(20.0)
+        .disbursementAmount(100.0)
+        .requestedNetDisbursementAmount(100.0)
+        .disbursementVatAmount(20.0)
+        .requestedDisbursementVatAmount(30.0)
+        .calculatedVatAmount(110.0)
+        .netProfitCostsAmount(500.0)
+        .requestedNetProfitCostsAmount(500.0)
+        .hourlyTotalAmount(650.0)
+        .netTravelCostsAmount(50.0)
+        .netWaitingCostsAmount(0.0)
+        .build();
+
+    FeeCalculationResponse expectedResponse = FeeCalculationResponse.builder()
+        .feeCode("INVA")
+        .schemeId("POL_FS2022")
+        .validationMessages(List.of(ValidationMessagesInner.builder()
+            .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .type(WARNING)
+            .build()))
+        .feeCalculation(expectedCalculation)
+        .build();
+
+    assertThat(response)
+        .usingRecursiveComparison()
+        .isEqualTo(expectedResponse);
+  }
 
   @Test
   void getSupportedCategories_shouldReturnEmptySet() {

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/PreOrderCoverHourlyRateCalculatorTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.PRE_ORDER_COVER;
 import static uk.gov.justice.laa.fee.scheme.enums.ErrorType.ERR_CRIME_PREORDER_COVER_UPPER_LIMIT;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
+import static uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner.TypeEnum.WARNING;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -26,6 +28,7 @@ import uk.gov.justice.laa.fee.scheme.feecalculator.BaseFeeCalculatorTest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculation;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationResponse;
+import uk.gov.justice.laa.fee.scheme.model.ValidationMessagesInner;
 
 @ExtendWith(MockitoExtension.class)
 class PreOrderCoverHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
@@ -138,5 +141,47 @@ class PreOrderCoverHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
           .usingRecursiveComparison()
           .isEqualTo(expectedResponse);
     }
+  }
+
+  @Test
+  void calculate_whenDisbursementVatExceedsCap_shouldReturnWarnDisbursementVatCapped() {
+
+    mockVatRatesService(true);
+
+    // disbursementVatAmount 5.0 > 20% of netDisbursementAmount 10.0 (max = 2.00)
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("PROP1")
+        .claimId("claim_123")
+        .uniqueFileNumber("110425/123")
+        .netProfitCosts(10.0)
+        .netDisbursementAmount(10.0)
+        .disbursementVatAmount(5.0)
+        .vatIndicator(true)
+        .netTravelCosts(10.0)
+        .netWaitingCosts(10.0)
+        .caseConcludedDate(LocalDate.of(2026, 1, 30))
+        .build();
+
+    FeeEntity feeEntity = FeeEntity.builder()
+        .feeCode("PROP1")
+        .feeScheme(FeeSchemesEntity.builder().schemeCode("POC_FS2022").build())
+        .categoryType(PRE_ORDER_COVER)
+        .feeType(HOURLY)
+        .upperCostLimit(BigDecimal.valueOf(100.0))
+        .build();
+
+    FeeCalculationResponse response = preOrderCoverHourlyRateCalculator.calculate(request, feeEntity);
+
+    // profitAndAdditional=30.0, vatOnProfit=6.0, netDisbAmt=10.0, cappedDisbVat=2.0 → total=48.0
+    assertThat(response.getFeeCalculation().getTotalAmount()).isEqualTo(48.0);
+    assertThat(response.getFeeCalculation().getDisbursementVatAmount()).isEqualTo(2.0);
+    assertThat(response.getFeeCalculation().getRequestedDisbursementVatAmount()).isEqualTo(5.0);
+    assertThat(response.getValidationMessages()).containsExactly(
+        ValidationMessagesInner.builder()
+            .code(WARN_DISBURSEMENT_VAT_CAPPED.getCode())
+            .message(WARN_DISBURSEMENT_VAT_CAPPED.getMessage())
+            .type(WARNING)
+            .build()
+    );
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
@@ -231,6 +231,8 @@ class FeeCalculationUtilTest {
     assertThat(result).isEqualTo(LocalDate.of(2022, 12, 1));
   }
 
+
+
   @Test
   void getCaseConcludedDate_shouldThrowValidationException_whenVatIndicatorIsTrueAndCaseConcludedDateIsNull() {
     FeeCalculationRequest request = getFeeCalculationRequest();

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/util/FeeCalculationUtilTest.java
@@ -232,32 +232,6 @@ class FeeCalculationUtilTest {
   }
 
   @Test
-  void getCaseConcludedDate_returnsNull_whenVatIndicatorIsFalseAndCaseConcludedDateIsNull() {
-    FeeCalculationRequest request = FeeCalculationRequest.builder()
-        .feeCode("ABC")
-        .vatIndicator(Boolean.FALSE)
-        .caseConcludedDate(null)
-        .build();
-
-    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
-
-    assertThat(result).isNull();
-  }
-
-  @Test
-  void getCaseConcludedDate_returnsNull_whenVatIndicatorIsNullAndCaseConcludedDateIsNull() {
-    FeeCalculationRequest request = FeeCalculationRequest.builder()
-        .feeCode("ABC")
-        .vatIndicator(null)
-        .caseConcludedDate(null)
-        .build();
-
-    LocalDate result = FeeCalculationUtil.getCaseConcludedDate(request);
-
-    assertThat(result).isNull();
-  }
-
-  @Test
   void getCaseConcludedDate_shouldThrowValidationException_whenVatIndicatorIsTrueAndCaseConcludedDateIsNull() {
     FeeCalculationRequest request = getFeeCalculationRequest();
     request.setCaseConcludedDate(null);

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -77,10 +77,11 @@ class VatRatesServiceTest {
 
   @Test
   void getVatRateForRequest_whenVatIndicatorIsFalse_shouldReturnZero() {
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
     FeeCalculationRequest request = FeeCalculationRequest.builder()
         .feeCode("ABC")
         .vatIndicator(false)
-        .caseConcludedDate(null)
+        .caseConcludedDate(caseConcludedDate)
         .build();
 
     BigDecimal result = vatRatesService.getVatRateForRequest(request);
@@ -90,10 +91,11 @@ class VatRatesServiceTest {
 
   @Test
   void getVatRateForRequest_whenVatIndicatorIsNull_shouldReturnZero() {
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
     FeeCalculationRequest request = FeeCalculationRequest.builder()
         .feeCode("ABC")
         .vatIndicator(null)
-        .caseConcludedDate(null)
+        .caseConcludedDate(caseConcludedDate)
         .build();
 
     BigDecimal result = vatRatesService.getVatRateForRequest(request);

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.fee.scheme.entity.VatRatesEntity;
 import uk.gov.justice.laa.fee.scheme.exception.CaseConcludedDateRequiredException;
+import uk.gov.justice.laa.fee.scheme.exception.VatRateNotFoundException;
 import uk.gov.justice.laa.fee.scheme.model.FeeCalculationRequest;
 import uk.gov.justice.laa.fee.scheme.repository.VatRatesRepository;
 
@@ -39,6 +40,21 @@ class VatRatesServiceTest {
     when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(vatRatesEntity);
 
     BigDecimal result = vatRatesService.getVatRateForDate(date, true);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForDate_shouldReturnVatRateRegardlessOfVatIndicator() {
+    LocalDate date = LocalDate.of(2025, 3, 15);
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(date)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForDate(date);
 
     assertThat(result).isEqualTo(new BigDecimal("20.00"));
   }
@@ -130,6 +146,16 @@ class VatRatesServiceTest {
     BigDecimal result = vatRatesService.getVatRateForDate(date);
 
     assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForDate_whenNoVatRateForDate_shouldThrowVatRateNotFound() {
+    LocalDate date = LocalDate.of(1980, 1, 1);
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(null);
+
+    assertThatThrownBy(() -> vatRatesService.getVatRateForDate(date))
+        .isInstanceOf(VatRateNotFoundException.class)
+        .hasMessageContaining("No VAT rate found for date: 1980-01-01");
   }
 
   @Test

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/service/VatRatesServiceTest.java
@@ -91,6 +91,7 @@ class VatRatesServiceTest {
 
   @Test
   void getVatRateForRequest_whenVatIndicatorIsNull_shouldReturnZero() {
+
     LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
     FeeCalculationRequest request = FeeCalculationRequest.builder()
         .feeCode("ABC")
@@ -115,4 +116,92 @@ class VatRatesServiceTest {
         .isInstanceOf(CaseConcludedDateRequiredException.class)
         .hasMessageContaining("Case Concluded Date is required for feeCode: ABC");
   }
+
+  @Test
+  void getVatRateForDate_withNoVatIndicator_shouldReturnVatRate() {
+    LocalDate date = LocalDate.of(2025, 3, 15);
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(date)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(date)).thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForDate(date);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForRequest_withOverrideVatIndicatorTrue_whenCaseConcludedDateSet_shouldReturnVatRate() {
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(true)
+        .caseConcludedDate(caseConcludedDate)
+        .build();
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(caseConcludedDate)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(caseConcludedDate))
+        .thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request, Boolean.TRUE);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @Test
+  void getVatRateForRequest_withOverrideVatIndicatorTrue_whenRequestVatFalse_shouldStillReturnVatRate() {
+    // Key scenario: disbursement VAT always fetches rate with Boolean.TRUE regardless of request vatIndicator
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(false)
+        .caseConcludedDate(caseConcludedDate)
+        .build();
+
+    VatRatesEntity vatRatesEntity = VatRatesEntity.builder()
+        .startDate(caseConcludedDate)
+        .vatRate(new BigDecimal("20.00"))
+        .build();
+    when(vatRatesRepository.findTopByStartDateLessThanEqualOrderByStartDateDesc(caseConcludedDate))
+        .thenReturn(vatRatesEntity);
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request, Boolean.TRUE);
+
+    assertThat(result).isEqualTo(new BigDecimal("20.00"));
+  }
+
+  @NullSource
+  @ValueSource(booleans = {false})
+  @ParameterizedTest
+  void getVatRateForRequest_withOverrideVatIndicatorFalseOrNull_shouldReturnZero(Boolean overrideVatIndicator) {
+    LocalDate caseConcludedDate = LocalDate.of(2025, 6, 1);
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(true)
+        .caseConcludedDate(caseConcludedDate)
+        .build();
+
+    BigDecimal result = vatRatesService.getVatRateForRequest(request, overrideVatIndicator);
+
+    assertThat(result).isEqualTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void getVatRateForRequest_withOverrideVatIndicatorTrue_whenCaseConcludedDateNullAndRequestVatTrue_shouldThrow() {
+    FeeCalculationRequest request = FeeCalculationRequest.builder()
+        .feeCode("ABC")
+        .vatIndicator(true)
+        .caseConcludedDate(null)
+        .build();
+
+    assertThatThrownBy(() -> vatRatesService.getVatRateForRequest(request, Boolean.TRUE))
+        .isInstanceOf(CaseConcludedDateRequiredException.class)
+        .hasMessageContaining("Case Concluded Date is required for feeCode: ABC");
+  }
+
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Release Specific Criteria

Check changes against the following acceptance criteria:

- [ ] VAT generally (on the rest of the claim) and VAT on disbursements
both will be calculated using the case concluded date to determine the VAT rate once we push the tickets to live. Except for any fee codes in the category of  Mediation which will remain using case start date to determine VAT - both on disbursements and generally (on the rest of the claim).

- [ ] If a provider enters a value in the VAT on disbursements field we do our calculation of the correct maximum amount they can claim  - based upon the net disbursements amount they have claimed and if their entry exceeds our calculated value we cap it at the amount we calculate it as.

- [ ] In all types of immigration fee codes we may have to calculate the allowable disbursement VAT amount not based on the providers entered net disbursement amount  but on an amount we've capped their net disbursements at if we have needed to cap it.

- [ ] If a provider leaves the VAT on disbursements field blank and we receive that field as null we wont perform any VAT on disbursements calculation.

- [ ] If a provider answers false to the VAT indicator - this applies only to the "general" VAT on the rest of the claim. If they've entered any value in VAT on disbursements they are still entitled to claim this VAT regardless of how the VAT indicator question was answered and we should perform the calculations on that VAT amount as written. The disbursement VAT amount has no dependency on whether the provider is claiming VAT on the rest of the claim.
