### PR TITLE
LFSP-531 Immigration and Asylum Hourly Disbursement VAT Limit

### DIFF
--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
@@ -11,7 +11,6 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_SUM
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
-import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
@@ -24,7 +23,6 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -243,7 +241,8 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     BigDecimal totalAmount = feeTotalWithBoltsOn.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotalWithBoltsOn, netProfitCosts, true, boltOnFeeDetails);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotalWithBoltsOn,
+        netProfitCosts, true, boltOnFeeDetails);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }

--- a/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
+++ b/scheme-service/src/main/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculator.java
@@ -11,7 +11,9 @@ import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_SUM
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildFeeCalculationResponse;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.buildValidationWarning;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.calculateVatAmount;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.capDisbursementVat;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.filterBoltOnFeeDetails;
+import static uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil.getCaseConcludedDate;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.DISBURSEMENT;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.PROFIT_COST;
 import static uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitType.TOTAL;
@@ -22,6 +24,7 @@ import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDouble;
 import static uk.gov.justice.laa.fee.scheme.util.NumberUtil.toDoubleOrNull;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +35,7 @@ import uk.gov.justice.laa.fee.scheme.entity.FeeEntity;
 import uk.gov.justice.laa.fee.scheme.enums.CategoryType;
 import uk.gov.justice.laa.fee.scheme.enums.WarningType;
 import uk.gov.justice.laa.fee.scheme.feecalculator.FeeCalculator;
+import uk.gov.justice.laa.fee.scheme.feecalculator.util.FeeCalculationUtil;
 import uk.gov.justice.laa.fee.scheme.feecalculator.util.boltons.BoltOnUtil;
 import uk.gov.justice.laa.fee.scheme.feecalculator.util.limit.LimitContext;
 import uk.gov.justice.laa.fee.scheme.model.BoltOnFeeDetails;
@@ -132,13 +136,13 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     // VAT is calculated on net profit costs only
     BigDecimal calculatedVatAmount = calculateVatAmount(netProfitCosts, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotal, netProfitCosts, false, null);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotal, netProfitCosts, false, null);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -176,13 +180,13 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotal.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotal, netProfitCosts, true, null);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotal, netProfitCosts, true, null);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -233,13 +237,13 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
 
     BigDecimal calculatedVatAmount = calculateVatAmount(feeWithoutDisbursements, vatRate);
 
-    BigDecimal disbursementVatAmount = toBigDecimal(feeCalculationRequest.getDisbursementVatAmount());
+    BigDecimal cappedDisbursementVatAmount = capDisbursementVat(feeCalculationRequest, validationMessages);
 
     // Calculate total amount
-    BigDecimal totalAmount = feeTotalWithBoltsOn.add(calculatedVatAmount).add(disbursementVatAmount);
+    BigDecimal totalAmount = feeTotalWithBoltsOn.add(calculatedVatAmount).add(cappedDisbursementVatAmount);
 
     FeeCalculation feeCalculation = buildFeeCalculation(feeCalculationRequest, totalAmount, vatRate,
-        calculatedVatAmount, netDisbursementAmount, feeTotalWithBoltsOn, netProfitCosts, true, boltOnFeeDetails);
+        calculatedVatAmount, netDisbursementAmount, cappedDisbursementVatAmount, feeTotalWithBoltsOn, netProfitCosts, true, boltOnFeeDetails);
 
     return buildFeeCalculationResponse(feeCalculationRequest, feeEntity, feeCalculation, validationMessages);
   }
@@ -262,11 +266,21 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
     }
   }
 
+  private BigDecimal capDisbursementVat(FeeCalculationRequest feeCalculationRequest, List<ValidationMessagesInner> validationMessages) {
+    BigDecimal disbursementVatRate = vatRatesService.getVatRateForDate(getCaseConcludedDate(feeCalculationRequest), true);
+    return FeeCalculationUtil.capDisbursementVat(
+            toBigDecimal(feeCalculationRequest.getNetDisbursementAmount()),
+            toBigDecimal(feeCalculationRequest.getDisbursementVatAmount()),
+            disbursementVatRate,
+            validationMessages);
+  }
+
   private FeeCalculation buildFeeCalculation(FeeCalculationRequest feeCalculationRequest,
                                              BigDecimal totalAmount,
                                              BigDecimal vatRate,
                                              BigDecimal calculatedVatAmount,
                                              BigDecimal disbursementAmount,
+                                             BigDecimal cappedDisbursementVatAmount,
                                              BigDecimal hourlyTotalAmount,
                                              BigDecimal netProfitCostsAmount,
                                              boolean includeCostOfCounsel,
@@ -278,7 +292,7 @@ public class ImmigrationAsylumHourlyRateCalculator implements FeeCalculator {
         .calculatedVatAmount(toDouble(calculatedVatAmount))
         .disbursementAmount(nonNull(feeCalculationRequest.getNetDisbursementAmount()) ? toDouble(disbursementAmount) : null)
         .requestedNetDisbursementAmount(feeCalculationRequest.getNetDisbursementAmount())
-        .disbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
+        .disbursementVatAmount(toDouble(cappedDisbursementVatAmount))
         .requestedDisbursementVatAmount(feeCalculationRequest.getDisbursementVatAmount())
         .hourlyTotalAmount(toDouble(hourlyTotalAmount))
         .netProfitCostsAmount(nonNull(feeCalculationRequest.getNetProfitCosts()) ? toDouble(netProfitCostsAmount) : null)

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/BaseFeeCalculatorTest.java
@@ -31,11 +31,6 @@ public abstract class BaseFeeCalculatorTest {
 
   protected void mockVatRatesVatIndicatorTrue() {
     when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
-        .thenReturn(new BigDecimal("20.00"));
-  }
-
-  protected void mockVatRatesVatIndicatorTrue() {
-    when(vatRatesService.getVatRateForDate(any(LocalDate.class), eq(true)))
             .thenReturn(new BigDecimal("20.00"));
   }
 }

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
@@ -311,7 +311,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
             .caseConcludedDate(LocalDate.of(2026, 1, 30))
             .build();
 
-    FeeEntity feeEntity = buildFeeEntity("IAXL");
+    FeeEntity feeEntity = buildFeeEntity("IAXC");
 
     FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
 
@@ -337,7 +337,7 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
             .caseConcludedDate(LocalDate.of(2026, 1, 30))
             .build();
 
-    FeeEntity feeEntity = buildFeeEntity("IAXL");
+    FeeEntity feeEntity = buildFeeEntity("IMCD");
 
     FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
@@ -2,8 +2,10 @@ package uk.gov.justice.laa.fee.scheme.feecalculator.hourly;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.justice.laa.fee.scheme.enums.CategoryType.IMMIGRATION_ASYLUM;
 import static uk.gov.justice.laa.fee.scheme.enums.FeeType.HOURLY;
+import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_DISBURSEMENT_VAT_CAPPED;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DETENTION_TRAVEL;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_DISB_LEGAL_HELP;
 import static uk.gov.justice.laa.fee.scheme.enums.WarningType.WARN_IMM_ASYLM_JR_FORM_FILLING;
@@ -58,6 +60,10 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
 
     mockVatRatesService(vatIndicator);
 
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest
         feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
@@ -96,22 +102,22 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   static Stream<Arguments> feeTestDataLegalHelp() {
     return Stream.of(
         // under profit costs and disbursements limits
-        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
-            314.3, 0, 289.63, 166.25, 123.38, List.of()),
-        Arguments.of("IAXL", VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
-            347.55, 33.25, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
+            310.3, 0, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IAXL", VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
+            343.55, 33.25, 289.63, 166.25, 123.38, List.of()),
 
         // over profit costs limit "with" prior authority
-        Arguments.of("IAXL", NO_VAT, AUTHORITY, 919.16, 123.38, 24.67,
-            1067.21, 0, 1042.54, 919.16, 123.38, List.of()),
-        Arguments.of("IAXL", VAT, AUTHORITY, 919.16, 123.38, 24.67,
-            1251.04, 183.83, 1042.54, 919.16, 123.38, List.of()),
+        Arguments.of("IAXL", NO_VAT, AUTHORITY, 919.16, 123.38, 20.67,
+            1063.21, 0, 1042.54, 919.16, 123.38, List.of()),
+        Arguments.of("IAXL", VAT, AUTHORITY, 919.16, 123.38, 20.67,
+            1247.04, 183.83, 1042.54, 919.16, 123.38, List.of()),
 
         // over profit costs limit "without" prior authority
-        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
-            948.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
-        Arguments.of("IAXL", VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
-            1108.05, 160, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
+            944.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IAXL", VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
+            1104.05, 160, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
 
         // over disbursements limit "with" prior authority
         Arguments.of("IAXL", NO_VAT, AUTHORITY, 166.25, 425.17, 85.03,
@@ -138,20 +144,20 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
             1445.03, 160, 1200, 800, 400, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP, WARN_IMM_ASYLM_DISB_LEGAL_HELP)),
 
         // IMXL
-        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
-            314.3, 0, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
+            310.3, 0, 289.63, 166.25, 123.38, List.of()),
 
         // IMXL over profit costs limit "without" prior authority
-        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
-            948.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
+            944.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
 
         // IMXL over disbursements limit "without" prior authority
         Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 425.17, 85.03,
             651.28, 0, 566.25, 166.25, 400, List.of(WARN_IMM_ASYLM_DISB_LEGAL_HELP)),
 
         // IA100
-        Arguments.of("IA100", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
-            314.3, 0, 289.63, 166.25, 123.38, List.of())
+        Arguments.of("IA100", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
+            310.3, 0, 289.63, 166.25, 123.38, List.of())
     );
   }
 
@@ -164,6 +170,10 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                           List<WarningType> expectedWarnings) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
@@ -227,13 +237,14 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                                     Double jrFormFilling,
                                                                                     List<WarningType> expectedWarnings) {
     mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode("IAXL")
         .startDate(LocalDate.of(2025, 5, 11))
         .netProfitCosts(166.25)
         .netDisbursementAmount(123.38)
-        .disbursementVatAmount(24.67)
+        .disbursementVatAmount(20.67)
         .detentionTravelAndWaitingCosts(detentionTravelAndWaitingCosts)
         .jrFormFilling(jrFormFilling)
         .vatIndicator(false)
@@ -258,6 +269,94 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   }
 
   @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenLegalHelpDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IAXL")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IAXL");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenClrDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IAXC")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IAXL");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  @ParameterizedTest
+  @MethodSource("disbursementVatWarningTestData")
+  void calculateFee_whenClrInterimDisbursementVatOverLimit_shouldReturnWarning(Double disbursementVat, Double expectedTotal, List<WarningType> expectedWarnings) {
+    mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
+    FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
+            .feeCode("IMCD")
+            .startDate(LocalDate.of(2025, 5, 11))
+            .netProfitCosts(166.25)
+            .netDisbursementAmount(123.38)
+            .disbursementVatAmount(disbursementVat)
+            .vatIndicator(false)
+            .immigrationPriorAuthorityNumber("priorAuth")
+            .caseConcludedDate(LocalDate.of(2026, 1, 30))
+            .build();
+
+    FeeEntity feeEntity = buildFeeEntity("IAXL");
+
+    FeeCalculationResponse result = immigrationAsylumHourlyRateCalculator.calculate(feeCalculationRequest, feeEntity);
+
+    assertThat(result).isNotNull();
+    assertEquals(result.getFeeCalculation().getTotalAmount(), expectedTotal);
+    assertWarnings(result.getValidationMessages(), expectedWarnings);
+  }
+
+  static Stream<Arguments> disbursementVatWarningTestData() {
+    return Stream.of(
+            // Legal Help
+            Arguments.of(314.37, 314.31, List.of(WARN_DISBURSEMENT_VAT_CAPPED)),
+            Arguments.of(1000.10, 314.31,  List.of(WARN_DISBURSEMENT_VAT_CAPPED)),
+            Arguments.of(200.46, 314.31, List.of(WARN_DISBURSEMENT_VAT_CAPPED))
+    );
+  }
+
+
+  @ParameterizedTest
   @MethodSource("feeTestDataClr")
   void calculateFee_whenClr_shouldReturnFeeCalculationResponse(String feeCode, boolean vatIndicator, String priorAuthority,
                                                                double netProfitCosts, double netCostOfCounsel, double netDisbursement,
@@ -266,9 +365,14 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
 
     mockVatRatesService(vatIndicator);
 
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(netProfitCosts)
         .netCostOfCounsel(netCostOfCounsel)
         .netDisbursementAmount(netDisbursement)
@@ -333,10 +437,13 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                        Double jrFormFilling, List<WarningType> expectedWarnings) {
 
     mockVatRatesService(false);
+    mockVatRatesVatIndicatorTrue();
+
 
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(486.78)
         .netCostOfCounsel(611.25)
         .netDisbursementAmount(152.34)
@@ -380,9 +487,15 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
                                                                       List<WarningType> expectedWarnings) {
 
     mockVatRatesService(vatIndicator);
+
+    if (!vatIndicator) {
+      mockVatRatesVatIndicatorTrue();
+    }
+
     FeeCalculationRequest feeCalculationRequest = FeeCalculationRequest.builder()
         .feeCode(feeCode)
         .startDate(LocalDate.of(2025, 5, 11))
+        .caseConcludedDate(LocalDate.of(2025, 6, 12))
         .netProfitCosts(netProfitCosts)
         .netCostOfCounsel(netCostOfCounsel)
         .boltOns(requestedBoltOns)
@@ -422,34 +535,34 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   static Stream<Arguments> feeTestDataClrInterim() {
     return Stream.of(
         // under total limit
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2054.83, 0, 2024.37, List.of()),
-        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2429.24, 374.41, 2024.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2034.83, 0, 2024.37, List.of()),
+        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2409.24, 374.41, 2024.37, List.of()),
 
         // over total "with" prior authority
-        Arguments.of("IACD", NO_VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2451.75, 0, 2421.29, List.of()),
-        Arguments.of("IACD", VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2905.54, 453.79, 2421.29, List.of()),
+        Arguments.of("IACD", NO_VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2431.75, 0, 2421.29, List.of()),
+        Arguments.of("IACD", VAT, AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2885.54, 453.79, 2421.29, List.of()),
 
         // over total limit "without" prior authority
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2404.46, 0, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
-        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 30.46,
-            2858.25, 453.79, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2384.46, 0, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
+        Arguments.of("IACD", VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 1008.17, 152.34, 10.46,
+            2838.25, 453.79, 2374, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_INTERIM)),
 
         // substantive hearing bolt on = false
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(false), 486.78, 611.25, 152.34, 30.46,
-            1752.83, 0, 1722.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, buildBoltOn(false), 486.78, 611.25, 152.34, 10.46,
+            1732.83, 0, 1722.37, List.of()),
 
         // no bolt ons
-        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, null, 486.78, 611.25, 152.34, 30.46,
-            1280.83, 0, 1250.37, List.of()),
+        Arguments.of("IACD", NO_VAT, NO_AUTHORITY, null, 486.78, 611.25, 152.34, 10.46,
+            1260.83, 0, 1250.37, List.of()),
 
         // IMCD
-        Arguments.of("IMCD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 30.46,
-            2054.83, 0, 2024.37, List.of())
+        Arguments.of("IMCD", NO_VAT, NO_AUTHORITY, buildBoltOn(true), 486.78, 611.25, 152.34, 10.46,
+            2034.83, 0, 2024.37, List.of())
     );
   }
 

--- a/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
+++ b/scheme-service/src/test/java/uk/gov/justice/laa/fee/scheme/feecalculator/hourly/ImmigrationAsylumHourlyRateCalculatorTest.java
@@ -102,22 +102,22 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
   static Stream<Arguments> feeTestDataLegalHelp() {
     return Stream.of(
         // under profit costs and disbursements limits
-        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
-            310.3, 0, 289.63, 166.25, 123.38, List.of()),
-        Arguments.of("IAXL", VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
-            343.55, 33.25, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
+            314.3, 0, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IAXL", VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
+            347.55, 33.25, 289.63, 166.25, 123.38, List.of()),
 
         // over profit costs limit "with" prior authority
-        Arguments.of("IAXL", NO_VAT, AUTHORITY, 919.16, 123.38, 20.67,
-            1063.21, 0, 1042.54, 919.16, 123.38, List.of()),
-        Arguments.of("IAXL", VAT, AUTHORITY, 919.16, 123.38, 20.67,
-            1247.04, 183.83, 1042.54, 919.16, 123.38, List.of()),
+        Arguments.of("IAXL", NO_VAT, AUTHORITY, 919.16, 123.38, 24.67,
+            1067.21, 0, 1042.54, 919.16, 123.38, List.of()),
+        Arguments.of("IAXL", VAT, AUTHORITY, 919.16, 123.38, 24.67,
+            1251.04, 183.83, 1042.54, 919.16, 123.38, List.of()),
 
         // over profit costs limit "without" prior authority
-        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
-            944.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
-        Arguments.of("IAXL", VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
-            1104.05, 160, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IAXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
+            948.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IAXL", VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
+            1108.05, 160, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
 
         // over disbursements limit "with" prior authority
         Arguments.of("IAXL", NO_VAT, AUTHORITY, 166.25, 425.17, 85.03,
@@ -144,20 +144,20 @@ class ImmigrationAsylumHourlyRateCalculatorTest extends BaseFeeCalculatorTest {
             1445.03, 160, 1200, 800, 400, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP, WARN_IMM_ASYLM_DISB_LEGAL_HELP)),
 
         // IMXL
-        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
-            310.3, 0, 289.63, 166.25, 123.38, List.of()),
+        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
+            314.3, 0, 289.63, 166.25, 123.38, List.of()),
 
         // IMXL over profit costs limit "without" prior authority
-        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 20.67,
-            944.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
+        Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 919.16, 123.38, 24.67,
+            948.05, 0, 923.38, 800, 123.38, List.of(WARN_IMM_ASYLM_PRIOR_AUTH_LEGAL_HELP)),
 
         // IMXL over disbursements limit "without" prior authority
         Arguments.of("IMXL", NO_VAT, NO_AUTHORITY, 166.25, 425.17, 85.03,
             651.28, 0, 566.25, 166.25, 400, List.of(WARN_IMM_ASYLM_DISB_LEGAL_HELP)),
 
         // IA100
-        Arguments.of("IA100", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 20.67,
-            310.3, 0, 289.63, 166.25, 123.38, List.of())
+        Arguments.of("IA100", NO_VAT, NO_AUTHORITY, 166.25, 123.38, 24.67,
+            314.3, 0, 289.63, 166.25, 123.38, List.of())
     );
   }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-531)

There is currently no validation on the value completed in the disbursements VAT amount field, this means in theory a provider could put any value in there and it goes unscrutinised. 
Given that it is only possible to claim a certain % of VAT on disbursements we are looking to implement a validation which checks against the value entered in the net disbursements field and verify whether the value entered in the disbursements on VAT field is above or below the expected percentage. If the value exceeds the percentage we will cap the costs and send a warning message. 

Updated calculations for LH, CLR, CLR interim.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
