### PR TITLE
LFSP-557 Major Version upgrade laa-spring-boot-common gradle plugin in Fee Scheme API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,11 @@
 
 version: 2
 
-# Uncomment 'registries' section to receive dependabot updates for 'laa-spring-boot-common'.
-# Ensure you have created a personal access token in GitHub and configured it with repo, write:packages and read:packages access.
-# The token must also be authorized with (MoJ) SSO. See link below for guidance:
-# https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
-#registries:
-#  spring-boot-common-github-packages:
-#    type: maven-repository
-#    url: https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common
-#    username: <your-username-here>
-#    password: ${{ secrets.REPO_TOKEN }}
-
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
-    registries: "*"
     groups:
       gradle-updates:
         exclude-patterns:

--- a/scheme-api/build.gradle
+++ b/scheme-api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.openapi.generator' version '7.23.0'
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
+    id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin'
 }
 
 repositories {

--- a/scheme-service/build.gradle
+++ b/scheme-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.freefair.lombok' version '9.5.0'
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
+    id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin'
     id "io.sentry.jvm.gradle" version "6.14.0"
     id 'info.solidsoft.pitest'
 }
@@ -106,7 +106,7 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.20.0'
 
-    implementation 'uk.gov.laa.springboot:laa-spring-boot-starter-auth'
+    implementation 'uk.gov.justice.service.laa:laa-spring-boot-starter-auth'
 
     implementation 'org.flywaydb:flyway-core:12.11.0'
     implementation 'org.flywaydb:flyway-database-postgresql:12.11.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,12 @@
 pluginManagement {
     repositories {
-        maven {
-            name = "gitHubPackages"
-            url = 'https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common'
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")?.trim() ?: settings.ext.find('project.ext.gitPackageUser')
-                password = System.getenv("GITHUB_TOKEN")?.trim() ?: settings.ext.find('project.ext.gitPackageKey')
-            }
-        }
+        mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         gradlePluginPortal()
     }
 
     plugins {
-        id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.3.4'
+        id 'uk.gov.justice.service.laa.laa-spring-boot-gradle-plugin' version '3.0.1'
         id 'info.solidsoft.pitest' version '1.19.0'
     }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LFSP-557)

Upgrade  Fee Scheme API to use the latest release of laa-spring-boot-common (v3.0.1).

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
